### PR TITLE
Update readme with deferred instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ SolidusAfterpay::PaymentMethod.new(
   preference_source: "afterpay_credentials"
 ).save
 ```
+## Deferred Payment Flow
+
+This flow completes the payment approval and starts the consumer's payment plan, but does not initiate the settlement process. This flow allows settlement of merchant funds to be deferred until order fulfilment can be confirmed.
+
+Simply check the deferred checkbox when creating the Afterpay payment_method to activate the deferred payment flow instead of the immediate payment flow.
+
+For more info about the deferred payment flow click [here](https://developers.afterpay.com/afterpay-online/reference#deferred-payment-flow).
 
 ## Usage
 


### PR DESCRIPTION
# Deferred Payment Flow Instructions

Add the deferred payment flow section to the readme giving a brief explanation of what the deferred payment flow actually is, explain how to activate it and add a link for more information to the Afterpay deferred payment flow documentation.

fix #9 