### PR TITLE
Display Afterpay only if the order is eligible for it

### DIFF
--- a/app/decorators/models/solidus_afterpay/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_afterpay/spree/order_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusAfterpay
+  module Spree
+    module OrderDecorator
+      def available_payment_methods
+        @available_payment_methods ||= super.select do |payment_method|
+          !payment_method.respond_to?(:available_for_order?) || payment_method.available_for_order?(self)
+        end
+      end
+
+      ::Spree::Order.prepend self
+    end
+  end
+end

--- a/app/models/solidus_afterpay/gateway.rb
+++ b/app/models/solidus_afterpay/gateway.rb
@@ -119,6 +119,12 @@ module SolidusAfterpay
       nil
     end
 
+    def retrieve_configuration
+      ::Afterpay::API::Configuration::Retrieve.call.body
+    rescue ::Afterpay::BaseError
+      nil
+    end
+
     private
 
     def immediate_capture(_amount, _response_code, gateway_options)

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -6,6 +6,9 @@ module SolidusAfterpay
     preference :secret_key, :string
     preference :deferred, :boolean
     preference :popup_window, :boolean
+    preference :minimum_amount, :decimal
+    preference :maximum_amount, :decimal
+    preference :currency, :string
 
     def gateway_class
       SolidusAfterpay::Gateway
@@ -27,6 +30,27 @@ module SolidusAfterpay
       return false unless response.success?
 
       response
+    end
+
+    def available_for_order?(order)
+      available_payment_currency == order.currency && available_payment_range.include?(order.total)
+    end
+
+    private
+
+    def available_payment_range
+      min = preferred_minimum_amount || configuration&.minimumAmount&.amount.to_f
+      max = preferred_maximum_amount || configuration&.maximumAmount&.amount.to_f
+
+      min..max
+    end
+
+    def available_payment_currency
+      preferred_currency || configuration&.maximumAmount&.currency
+    end
+
+    def configuration
+      @configuration ||= gateway.retrieve_configuration
     end
   end
 end

--- a/spec/fixtures/vcr_casettes/retrieve_configuration/valid.yml
+++ b/spec/fixtures/vcr_casettes/retrieve_configuration/valid.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.us-sandbox.afterpay.com/v2/configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SolidusAfterpay/0.0.1 (Solidus/3.0.1; Ruby/2.6.6; Merchant/100101481) https://
+      Authorization:
+      - Basic <ENCODED_AUTH_HEADER>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 25 Aug 2021 14:56:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '151'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-transform, max-age=1800
+      Http-Correlation-Id:
+      - u73bnoiwo265mfjp7rdrdzfsxu
+      Vary:
+      - Accept-Encoding
+      X-Envoy-Upstream-Service-Time:
+      - '10'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Set-Cookie:
+      - __cf_bm=ebd26f3256f7c877137bf42087fa5550fed5965e-1629903362-1800-AcvTlx8l0pTK7CNPb9AuSNR0Gno8NZxAq/ln/lsb1QfRDTKngcaw3pe7umDu3S2LL583bb0jFHJGa/Lbzh3XP31WX5N+vTDZeMa33NSOwYtV;
+        path=/; expires=Wed, 25-Aug-21 15:26:02 GMT; domain=.afterpay.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6845aa2e5871cd32-FCO
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "minimumAmount" : {
+            "amount" : "1.00",
+            "currency" : "USD"
+          },
+          "maximumAmount" : {
+            "amount" : "1000.00",
+            "currency" : "USD"
+          }
+        }
+  recorded_at: Wed, 25 Aug 2021 14:56:02 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/solidus_afterpay/gateway_spec.rb
+++ b/spec/models/solidus_afterpay/gateway_spec.rb
@@ -343,4 +343,24 @@ RSpec.describe SolidusAfterpay::Gateway do
       end
     end
   end
+
+  describe '#retrieve_configuration' do
+    subject(:response) { gateway.retrieve_configuration }
+
+    context 'with valid response', vcr: 'retrieve_configuration/valid' do
+      it 'retrieves the afterpay configuration' do
+        expect(response).to include('minimumAmount', 'maximumAmount')
+      end
+    end
+
+    context 'with invalid response' do
+      before do
+        allow(::Afterpay::API::Configuration::Retrieve).to receive(:call).and_raise(::Afterpay::BaseError)
+      end
+
+      it 'retrieves the afterpay configuration' do
+        expect(response).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spree::Order, type: :model do
   let(:user) { create(:user, email: "solidus@example.com") }
   let(:order) { create(:order, user: user, store: store) }
 
-  context "#available_payment_methods" do
+  describe "#available_payment_methods" do
     it "includes frontend payment methods" do
       payment_method = Spree::PaymentMethod::Check.create!({
         name: "Fake",
@@ -28,6 +28,7 @@ RSpec.describe Spree::Order, type: :model do
       expect(order.available_payment_methods).to include(payment_method)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it "does not include a payment method twice" do
       payment_method = Spree::PaymentMethod::Check.create!({
         name: "Fake",
@@ -38,6 +39,7 @@ RSpec.describe Spree::Order, type: :model do
       expect(order.available_payment_methods.count).to eq(1)
       expect(order.available_payment_methods).to include(payment_method)
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it "does not include inactive payment methods" do
       Spree::PaymentMethod::Check.create!({
@@ -66,7 +68,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "respects the order of methods based on position" do
-        expect(subject).to eq([second_method, first_method])
+        is_expected.to eq([second_method, first_method])
       end
     end
 
@@ -90,11 +92,12 @@ RSpec.describe Spree::Order, type: :model do
           )
         end
 
-        context 'and the store has an extra payment method unavailable to users' do
+        # rubocop:disable RSpec/NestedGroups
+        context 'when the store has an extra payment method unavailable to users' do
           let!(:admin_only_payment_method) do
             create(:payment_method,
-                                                     available_to_users: false,
-                                                     available_to_admin: true)
+              available_to_users: false,
+              available_to_admin: true)
           end
 
           before do
@@ -107,6 +110,7 @@ RSpec.describe Spree::Order, type: :model do
             )
           end
         end
+        # rubocop:enable RSpec/NestedGroups
       end
 
       context 'when the store does not have payment methods' do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Order, type: :model do
+  let(:store) { create(:store) }
+  let(:user) { create(:user, email: "solidus@example.com") }
+  let(:order) { create(:order, user: user, store: store) }
+
+  context "#available_payment_methods" do
+    it "includes frontend payment methods" do
+      payment_method = Spree::PaymentMethod::Check.create!({
+        name: "Fake",
+        active: true,
+        available_to_users: true,
+        available_to_admin: false
+      })
+      expect(order.available_payment_methods).to include(payment_method)
+    end
+
+    it "includes 'both' payment methods" do
+      payment_method = Spree::PaymentMethod::Check.create!({
+        name: "Fake",
+        active: true,
+        available_to_users: true,
+        available_to_admin: true
+      })
+      expect(order.available_payment_methods).to include(payment_method)
+    end
+
+    it "does not include a payment method twice" do
+      payment_method = Spree::PaymentMethod::Check.create!({
+        name: "Fake",
+        active: true,
+        available_to_users: true,
+        available_to_admin: true
+      })
+      expect(order.available_payment_methods.count).to eq(1)
+      expect(order.available_payment_methods).to include(payment_method)
+    end
+
+    it "does not include inactive payment methods" do
+      Spree::PaymentMethod::Check.create!({
+        name: "Fake",
+        active: false,
+        available_to_users: true,
+        available_to_admin: true
+      })
+      expect(order.available_payment_methods.count).to eq(0)
+    end
+
+    context "with more than one payment method" do
+      subject { order.available_payment_methods }
+
+      let!(:first_method) {
+        FactoryBot.create(:payment_method, available_to_users: true,
+                                               available_to_admin: true)
+      }
+      let!(:second_method) {
+        FactoryBot.create(:payment_method, available_to_users: true,
+                                               available_to_admin: true)
+      }
+
+      before do
+        second_method.move_to_top
+      end
+
+      it "respects the order of methods based on position" do
+        expect(subject).to eq([second_method, first_method])
+      end
+    end
+
+    context 'when the order has a store' do
+      let(:order) { create(:order) }
+
+      let!(:store_with_payment_methods) do
+        create(:store,
+          payment_methods: [payment_method_with_store])
+      end
+      let!(:payment_method_with_store) { create(:payment_method) }
+      let!(:store_without_payment_methods) { create(:store) }
+      let!(:payment_method_without_store) { create(:payment_method) }
+
+      context 'when the store has payment methods' do
+        before { order.update!(store: store_with_payment_methods) }
+
+        it 'returns only the matching payment methods for that store' do
+          expect(order.available_payment_methods).to match_array(
+            [payment_method_with_store]
+          )
+        end
+
+        context 'and the store has an extra payment method unavailable to users' do
+          let!(:admin_only_payment_method) do
+            create(:payment_method,
+                                                     available_to_users: false,
+                                                     available_to_admin: true)
+          end
+
+          before do
+            store_with_payment_methods.payment_methods << admin_only_payment_method
+          end
+
+          it 'returns only the payment methods available to users for that store' do
+            expect(order.available_payment_methods).to match_array(
+              [payment_method_with_store]
+            )
+          end
+        end
+      end
+
+      context 'when the store does not have payment methods' do
+        before { order.update!(store: store_without_payment_methods) }
+
+        it 'returns all matching payment methods regardless of store' do
+          expect(order.available_payment_methods).to match_array(
+            [payment_method_with_store, payment_method_without_store]
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The SolidusAfterpay::PaymentMethod is eligible for a specific order only if the
order amount is between the merchant's applicable payment limits.

If the `minimumAmount` and `maximumAmount` are not set in the payment method, they
will be retrieved by a call to the [Afterpay Get Configuration` endpoint](https://developers.afterpay.com/afterpay-online/reference#configuration).
