### PR TITLE
Popup window

### DIFF
--- a/app/controllers/solidus_afterpay/callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/callbacks_controller.rb
@@ -18,8 +18,10 @@ module SolidusAfterpay
       if ::Spree::OrderUpdateAttributes.new(order, update_params, request_env: request.headers.env).apply
         order.next
       end
-
-      redirect_to checkout_state_path(order.state)
+      respond_to do |format|
+        format.html { redirect_to checkout_state_path(order.state) }
+        format.json { render json: { redirect_url: checkout_state_url(order.state) } }
+      end
     end
 
     def cancel

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -5,6 +5,7 @@ module SolidusAfterpay
     preference :merchant_id, :string
     preference :secret_key, :string
     preference :deferred, :boolean
+    preference :popup_window, :boolean
 
     def gateway_class
       SolidusAfterpay::Gateway

--- a/app/views/spree/checkout/payment/_afterpay.html.erb
+++ b/app/views/spree/checkout/payment/_afterpay.html.erb
@@ -5,4 +5,5 @@
   class="hidden"
   data-payment-method-id="<%= payment_method.id %>"
   data-order-number="<%= @order.number %>"
+  data-popup-window="<%= payment_method.preferred_popup_window %>"
 ></div>


### PR DESCRIPTION
# Afterpay Popup Window

Add the functionality for the popup window from Afterpay.

Add the preference `popup_window` in the `payment_method` and store that result in the data attribute in the div.

Add if statement checking whether the value of the data attribute is true or false; if true, it will run the `openAfterpayWindow` function; else, it will run the redirect from Afterpay.

fix #13