### PR TITLE
Add authorization checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,4 +11,4 @@ RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/NestedGroups:
-  Enabled: false
+  Max: 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,4 +11,4 @@ RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 4
+  Enabled: false

--- a/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
+++ b/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
@@ -1,55 +1,77 @@
-$(function() {
+$(function () {
   function enableSubmit() {
     /* If we're using jquery-ujs on the frontend, it will automatically disable
-      * the submit button, but do so in a setTimeout here:
-      * https://github.com/rails/jquery-rails/blob/master/vendor/assets/javascripts/jquery_ujs.js#L517
-      * The only way we can re-enable it is by delaying longer than that timeout
-      * or stopping propagation so their submit handler doesn't run. */
-    if($.rails && typeof $.rails.enableFormElement !== 'undefined') {
-      setTimeout(function() {
+     * the submit button, but do so in a setTimeout here:
+     * https://github.com/rails/jquery-rails/blob/master/vendor/assets/javascripts/jquery_ujs.js#L517
+     * The only way we can re-enable it is by delaying longer than that timeout
+     * or stopping propagation so their submit handler doesn't run. */
+    if ($.rails && typeof $.rails.enableFormElement !== "undefined") {
+      setTimeout(function () {
         $.rails.enableFormElement($submitButton);
-        $submitButton.attr("disabled", false).removeClass("disabled").addClass("primary");
+        $submitButton
+          .attr("disabled", false)
+          .removeClass("disabled")
+          .addClass("primary");
       }, 100);
-    } else if(typeof Rails !== 'undefined' && typeof Rails.enableElement !== 'undefined') {
+    } else if (
+      typeof Rails !== "undefined" &&
+      typeof Rails.enableElement !== "undefined"
+    ) {
       /* Indicates that we have rails-ujs instead of jquery-ujs. Rails-ujs was added to rails
-        * core in Rails 5.1.0 */
-      setTimeout(function() {
+       * core in Rails 5.1.0 */
+      setTimeout(function () {
         Rails.enableElement($submitButton[0]);
-        $submitButton.attr("disabled", false).removeClass("disabled").addClass("primary");
+        $submitButton
+          .attr("disabled", false)
+          .removeClass("disabled")
+          .addClass("primary");
       }, 100);
     } else {
-      $submitButton.attr("disabled", false).removeClass("disabled").addClass("primary");
+      $submitButton
+        .attr("disabled", false)
+        .removeClass("disabled")
+        .addClass("primary");
     }
   }
 
   function disableSubmit() {
-    $submitButton.attr("disabled", true).removeClass("primary").addClass("disabled");
+    $submitButton
+      .attr("disabled", true)
+      .removeClass("primary")
+      .addClass("disabled");
   }
 
   function addFormHook() {
-    $paymentForm.on('submit', function(event) {
-      var selectedPaymentMethodId = parseInt($("#payment-method-fields input[type='radio']:checked").val());
+    $paymentForm.on("submit", function (event) {
+      var selectedPaymentMethodId = parseInt(
+        $("#payment-method-fields input[type='radio']:checked").val()
+      );
 
-      if(paymentMethodId === selectedPaymentMethodId) {
+      if (paymentMethodId === selectedPaymentMethodId) {
         event.preventDefault();
         disableSubmit();
 
         Spree.ajax({
-          method: 'POST',
-          url: '/solidus_afterpay/checkouts.json',
-          data: { order_number: orderNumber, payment_method_id: paymentMethodId }
-        }).success(function(response) {
-          onSuccess(response);
-        }).error(function(response) {
-          onError(response);
-        });
+          method: "POST",
+          url: "/solidus_afterpay/checkouts.json",
+          data: {
+            order_number: orderNumber,
+            payment_method_id: paymentMethodId,
+          },
+        })
+          .success(function (response) {
+            onSuccess(response);
+          })
+          .error(function (response) {
+            onError(response);
+          });
       }
     });
   }
 
   function onSuccess(response) {
-    AfterPay.initialize({ countryCode: 'US' });
-    if(popupWindow){
+    AfterPay.initialize({ countryCode: "US" });
+    if (popupWindow) {
       openAfterpayPopup(response);
     } else {
       AfterPay.redirect({ token: response.token });
@@ -60,41 +82,49 @@ $(function() {
     enableSubmit();
   }
 
-  function openAfterpayPopup(response){
-    AfterPay.onComplete = function(event) {
-      if(event.data.status == 'SUCCESS') {
+  function openAfterpayPopup(response) {
+    AfterPay.onComplete = function (event) {
+      if (event.data.status == "SUCCESS") {
         onAfterpaySuccess(event);
       } else {
         onAfterpayCancel(event);
       }
-    }
+    };
     AfterPay.open();
     AfterPay.transfer({ token: response.token });
   }
 
   function onAfterpaySuccess(event) {
     Spree.ajax({
-      method: 'POST',
-      url: '/solidus_afterpay/callbacks/confirm.json',
-      data: { order_number: orderNumber, payment_method_id: paymentMethodId, order_token: event.data.orderToken }
-    }).success(function(response) {
-      window.location.href = response.redirect_url;
-    }).error(function(response) {
-      enableSubmit();
-    });
+      method: "POST",
+      url: "/solidus_afterpay/callbacks/confirm.json",
+      data: {
+        order_number: orderNumber,
+        payment_method_id: paymentMethodId,
+        order_token: event.data.orderToken,
+      },
+    })
+      .success(function (response) {
+        window.location.href = response.redirect_url;
+      })
+      .error(function (response) {
+        enableSubmit();
+      });
   }
 
   function onAfterpayCancel(event) {
     enableSubmit();
   }
 
-  if($('#afterpay_checkout_payload').length > 0) {
+  if ($("#afterpay_checkout_payload").length > 0) {
     var $paymentForm = $("#checkout_form_payment");
     var $submitButton = $("input[type='submit']", $paymentForm);
 
-    var paymentMethodId = $('#afterpay_checkout_payload').data('payment-method-id');
-    var orderNumber = $('#afterpay_checkout_payload').data('order-number');
-    var popupWindow = $('#afterpay_checkout_payload').data('popup-window');
+    var paymentMethodId = $("#afterpay_checkout_payload").data(
+      "payment-method-id"
+    );
+    var orderNumber = $("#afterpay_checkout_payload").data("order-number");
+    var popupWindow = $("#afterpay_checkout_payload").data("popup-window");
 
     addFormHook();
   }

--- a/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
+++ b/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
@@ -59,7 +59,7 @@ $(function() {
   function onError(response) {
     enableSubmit();
   }
- 
+
   function openAfterpayPopup(response){
     AfterPay.onComplete = function(event) {
       if(event.data.status == 'SUCCESS') {
@@ -74,7 +74,7 @@ $(function() {
 
   function onAfterpaySuccess(event) {
     Spree.ajax({
-      method: 'GET',
+      method: 'POST',
       url: '/solidus_afterpay/callbacks/confirm.json',
       data: { order_number: orderNumber, payment_method_id: paymentMethodId, order_token: event.data.orderToken }
     }).success(function(response) {

--- a/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
+++ b/app/assets/javascripts/solidus_afterpay/afterpay_checkout.js
@@ -76,7 +76,7 @@ $(function() {
     Spree.ajax({
       method: 'GET',
       url: '/solidus_afterpay/callbacks/confirm.json',
-      data: { order_number: orderNumber, payment_method_id: paymentMethodId, orderToken: event.data.orderToken }
+      data: { order_number: orderNumber, payment_method_id: paymentMethodId, order_token: event.data.orderToken }
     }).success(function(response) {
       window.location.href = response.redirect_url;
     }).error(function(response) {

--- a/app/controllers/solidus_afterpay/base_controller.rb
+++ b/app/controllers/solidus_afterpay/base_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SolidusAfterpay
+  class BaseController < ::Spree::BaseController
+    protect_from_forgery unless: -> { request.format.json? }
+
+    rescue_from ::ActiveRecord::RecordNotFound, with: :resource_not_found
+    rescue_from ::CanCan::AccessDenied, with: :unauthorized
+
+    private
+
+    def order_token
+      cookies.signed[:guest_token]
+    end
+
+    def resource_not_found
+      respond_to do |format|
+        format.html { redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.resource_not_found') }
+        format.json { render json: { error: I18n.t('solidus_afterpay.resource_not_found') }, status: :not_found }
+      end
+    end
+
+    def unauthorized
+      respond_to do |format|
+        format.html { redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.unauthorized') }
+        format.json { render json: { error: I18n.t('solidus_afterpay.unauthorized') }, status: :unauthorized }
+      end
+    end
+  end
+end

--- a/app/controllers/solidus_afterpay/callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/callbacks_controller.rb
@@ -32,7 +32,7 @@ module SolidusAfterpay
           payment_method: payment_method,
           amount: order.total,
           source_attributes: {
-            token: order_token
+            token: afterpay_order_token
           }
         }]
       }
@@ -46,7 +46,7 @@ module SolidusAfterpay
       @payment_method ||= SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
     end
 
-    def order_token
+    def afterpay_order_token
       params[:orderToken] || params[:order_token]
     end
 
@@ -58,7 +58,7 @@ module SolidusAfterpay
     end
 
     def ensure_afterpay_order_token_presence
-      return if order_token
+      return if afterpay_order_token
 
       respond_to do |format|
         format.html {

--- a/app/controllers/solidus_afterpay/callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/callbacks_controller.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusAfterpay
-  class CallbacksController < ::Spree::BaseController
-    protect_from_forgery except: [:confirm, :cancel]
-
-    rescue_from ::ActiveRecord::RecordNotFound, with: :resource_not_found
-    rescue_from ::CanCan::AccessDenied, with: :unauthorized
-
+  class CallbacksController < SolidusAfterpay::BaseController
     before_action :ensure_afterpay_order_token_presence, only: :confirm
     before_action :ensure_order_not_completed, only: :confirm
 
@@ -51,24 +46,6 @@ module SolidusAfterpay
 
     def afterpay_order_token
       params[:orderToken] || params[:order_token]
-    end
-
-    def order_token
-      cookies.signed[:guest_token]
-    end
-
-    def resource_not_found
-      respond_to do |format|
-        format.html { redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.resource_not_found') }
-        format.json { render json: { error: I18n.t('solidus_afterpay.resource_not_found') }, status: :not_found }
-      end
-    end
-
-    def unauthorized
-      respond_to do |format|
-        format.html { redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.unauthorized') }
-        format.json { render json: { error: I18n.t('solidus_afterpay.unauthorized') }, status: :unauthorized }
-      end
     end
 
     def ensure_afterpay_order_token_presence

--- a/app/controllers/solidus_afterpay/callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/callbacks_controller.rb
@@ -6,18 +6,14 @@ module SolidusAfterpay
 
     rescue_from ::ActiveRecord::RecordNotFound, with: :resource_not_found
 
+    before_action :ensure_afterpay_order_token_presence, only: :confirm
+    before_action :ensure_order_not_completed, only: :confirm
+
     def confirm
-      if !order_token
-        return redirect_to checkout_state_path(order.state), notice: I18n.t('solidus_afterpay.order_token_not_found')
-      end
-
-      if order.complete?
-        return redirect_to spree.order_path(order), notice: I18n.t('spree.order_already_completed')
-      end
-
       if ::Spree::OrderUpdateAttributes.new(order, update_params, request_env: request.headers.env).apply
         order.next
       end
+
       respond_to do |format|
         format.html { redirect_to checkout_state_path(order.state) }
         format.json { render json: { redirect_url: checkout_state_url(order.state) } }
@@ -51,11 +47,34 @@ module SolidusAfterpay
     end
 
     def order_token
-      params[:orderToken]
+      params[:orderToken] || params[:order_token]
     end
 
     def resource_not_found
-      redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.resource_not_found')
+      respond_to do |format|
+        format.html { redirect_to spree.cart_path, notice: I18n.t('solidus_afterpay.resource_not_found') }
+        format.json { render json: { error: I18n.t('solidus_afterpay.resource_not_found') }, status: :not_found }
+      end
+    end
+
+    def ensure_afterpay_order_token_presence
+      return if order_token
+
+      respond_to do |format|
+        format.html {
+          redirect_to checkout_state_path(order.state), notice: I18n.t('solidus_afterpay.order_token_not_found')
+        }
+        format.json { render json: { error: I18n.t('solidus_afterpay.order_token_not_found') }, status: :not_found }
+      end
+    end
+
+    def ensure_order_not_completed
+      return unless order.complete?
+
+      respond_to do |format|
+        format.html { redirect_to spree.order_path(order), notice: I18n.t('spree.order_already_completed') }
+        format.json { render json: { error: I18n.t('spree.order_already_completed') }, status: :unprocessable_entity }
+      end
     end
   end
 end

--- a/app/controllers/solidus_afterpay/checkouts_controller.rb
+++ b/app/controllers/solidus_afterpay/checkouts_controller.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusAfterpay
-  class CheckoutsController < ::Spree::BaseController
-    protect_from_forgery except: [:create]
-
-    rescue_from ::ActiveRecord::RecordNotFound, with: :resource_not_found
-    rescue_from ::CanCan::AccessDenied, with: :unauthorized
-
+  class CheckoutsController < SolidusAfterpay::BaseController
     def create
       authorize! :update, order, order_token
 
@@ -47,18 +42,6 @@ module SolidusAfterpay
       params[:redirect_cancel_url] || solidus_afterpay.callbacks_cancel_url(
         order_number: order.number, payment_method_id: payment_method.id
       )
-    end
-
-    def order_token
-      cookies.signed[:guest_token]
-    end
-
-    def resource_not_found
-      render json: { error: I18n.t('solidus_afterpay.resource_not_found') }, status: :not_found
-    end
-
-    def unauthorized
-      render json: { error: I18n.t('solidus_afterpay.unauthorized') }, status: :unauthorized
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,3 +9,4 @@ en:
     payment_declined: Payment declined. Please contact the Afterpay Customer Service team for more information.
     resource_not_found: The resource you were looking for could not be found.
     order_token_not_found: Invalid order confirmation data passed in.
+    unauthorized: You are not authorized to perform that action.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 SolidusAfterpay::Engine.routes.draw do
-  get '/callbacks/confirm', to: '/solidus_afterpay/callbacks#confirm'
+  match '/callbacks/confirm', to: '/solidus_afterpay/callbacks#confirm', via: %i[get post]
   get '/callbacks/cancel', to: '/solidus_afterpay/callbacks#cancel'
   post '/checkouts', to: '/solidus_afterpay/checkouts#create'
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe Spree::Order, type: :model do
           third_method
         end
 
-        # rubocop:disable RSpec/NestedGroups
         context 'when it responds with true' do
           before do
             FakePaymentMethod.class_eval { def available_for_order?(_order); true; end }
@@ -103,7 +102,6 @@ RSpec.describe Spree::Order, type: :model do
             is_expected.to eq([second_method, first_method])
           end
         end
-        # rubocop:enable RSpec/NestedGroups
       end
     end
 
@@ -127,7 +125,6 @@ RSpec.describe Spree::Order, type: :model do
           )
         end
 
-        # rubocop:disable RSpec/NestedGroups
         context 'when the store has an extra payment method unavailable to users' do
           let!(:admin_only_payment_method) do
             create(:payment_method,
@@ -145,7 +142,6 @@ RSpec.describe Spree::Order, type: :model do
             )
           end
         end
-        # rubocop:enable RSpec/NestedGroups
       end
 
       context 'when the store does not have payment methods' do

--- a/spec/requests/solidus_afterpay/callbacks_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/callbacks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SolidusAfterpay::CallbacksController, type: :request do
@@ -17,8 +19,9 @@ describe SolidusAfterpay::CallbacksController, type: :request do
   describe 'GET confirm' do
     subject(:request) { get '/solidus_afterpay/callbacks/confirm', params: params }
 
-    let(:order) { create(:order_with_totals, state: 'payment') }
+    let(:order) { create(:order_with_totals, state: 'payment', user: user) }
     let(:payment_method) { create(:afterpay_payment_method) }
+    let(:user) { create(:user) }
 
     let(:order_token) { 'ORDER_TOKEN' }
     let(:order_number) { order.number }
@@ -26,82 +29,98 @@ describe SolidusAfterpay::CallbacksController, type: :request do
 
     let(:params) { { orderToken: order_token, order_number: order_number, payment_method_id: payment_method_id } }
 
-    context 'with valid data' do
+    context 'when the user is logged in', with_signed_in_user: true do
+      context 'with valid data' do
+        it 'redirects to the order next checkout state page' do
+          request
+          expect(response).to redirect_to('/checkout/confirm')
+        end
+
+        it 'moves the order to its next state' do
+          expect { request }.to change { order.reload.state }.from('payment').to('confirm')
+        end
+
+        it 'creates a payment' do
+          expect { request }.to change { order.payments.count }.from(0).to(1)
+        end
+
+        it 'sets the payment total equal to the order total' do
+          request
+          expect(order.payments.last.amount).to eq(order.total)
+        end
+
+        it 'creates a payment source and assigns the order token to it' do
+          request
+          expect(order.payments.last.payment_source.token).to eq(order_token)
+        end
+      end
+
+      context 'when the order_token is missing' do
+        let(:order_token) { nil }
+
+        it 'redirects to the order current checkout state page' do
+          request
+          expect(response).to redirect_to('/checkout/payment')
+        end
+      end
+
+      context 'when the order_number is invalid' do
+        let(:order_number) { 'INVALID_ORDER_NUMBER' }
+
+        it 'redirects to the cart page' do
+          request
+          expect(response).to redirect_to('/cart')
+        end
+
+        it 'sets a resource not found flash message' do
+          request
+          expect(flash[:notice]).to eq('The resource you were looking for could not be found.')
+        end
+      end
+
+      context 'when the payment_method_id is invalid' do
+        let(:payment_method_id) { 0 }
+
+        it 'redirects to the cart page' do
+          request
+          expect(response).to redirect_to('/cart')
+        end
+
+        it 'sets a resource not found flash message' do
+          request
+          expect(flash[:notice]).to eq('The resource you were looking for could not be found.')
+        end
+      end
+
+      context 'when the order is already in confirm state' do
+        let(:order) { create(:order_with_totals, state: 'confirm') }
+
+        it "doesn't move the order to its next state" do
+          expect { request }.not_to(change { order.reload.state })
+        end
+      end
+
+      context 'when the order is already completed' do
+        let(:order) { create(:completed_order_with_totals) }
+
+        it 'redirects to the order detail page' do
+          request
+          expect(response).to redirect_to("/orders/#{order.number}")
+        end
+      end
+    end
+
+    context 'when the user is a guest user', with_guest_session: true do
       it 'redirects to the order next checkout state page' do
         request
         expect(response).to redirect_to('/checkout/confirm')
       end
-
-      it 'moves the order to its next state' do
-        expect { request }.to change { order.reload.state }.from('payment').to('confirm')
-      end
-
-      it 'creates a payment' do
-        expect { request }.to change { order.payments.count }.from(0).to(1)
-      end
-
-      it 'sets the payment total equal to the order total' do
-        request
-        expect(order.payments.last.amount).to eq(order.total)
-      end
-
-      it 'creates a payment source and assigns the order token to it' do
-        request
-        expect(order.payments.last.payment_source.token).to eq(order_token)
-      end
     end
 
-    context 'when the order_token is missing' do
-      let(:order_token) { nil }
-
-      it 'redirects to the order current checkout state page' do
-        request
-        expect(response).to redirect_to('/checkout/payment')
-      end
-    end
-
-    context 'when the order_number is invalid' do
-      let(:order_number) { 'INVALID_ORDER_NUMBER' }
-
-      it 'redirects to the cart page' do
+    context 'when the user is not logged in' do
+      it 'redirects the user to vallalah' do
         request
         expect(response).to redirect_to('/cart')
-      end
-
-      it 'sets a resource not found flash message' do
-        request
-        expect(flash[:notice]).to eq('The resource you were looking for could not be found.')
-      end
-    end
-
-    context 'when the payment_method_id is invalid' do
-      let(:payment_method_id) { 0 }
-
-      it 'redirects to the cart page' do
-        request
-        expect(response).to redirect_to('/cart')
-      end
-
-      it 'sets a resource not found flash message' do
-        request
-        expect(flash[:notice]).to eq('The resource you were looking for could not be found.')
-      end
-    end
-
-    context 'when the order is already in confirm state' do
-      let(:order) { create(:order_with_totals, state: 'confirm') }
-
-      it "doesn't move the order to its next state" do
-        expect { request }.not_to(change { order.reload.state })
-      end
-    end
-
-    context 'when the order is already completed' do
-      let(:order) { create(:completed_order_with_totals) }
-
-      it 'redirects to the order detail page' do
-        request
-        expect(response).to redirect_to("/orders/#{order.number}")
       end
     end
   end

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SolidusAfterpay::CheckoutsController, type: :request do
   describe 'POST create' do
-    subject(:request) { post '/solidus_afterpay/checkouts', params: params }
+    subject(:request) { post '/solidus_afterpay/checkouts.json', params: params }
 
-    let(:order) { create(:order_with_totals, state: 'payment') }
+    let(:order) { create(:order_with_totals, state: 'payment', user: user) }
     let(:payment_method) { create(:afterpay_payment_method) }
+    let(:user) { create(:user) }
 
     let(:order_number) { order.number }
     let(:payment_method_id) { payment_method.id }
@@ -16,6 +19,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
     let(:gateway_response_success?) { true }
     let(:gateway_response_message) { 'Success message' }
     let(:gateway_response_params) { { 'token' => order_token } }
+
     let(:gateway_response) do
       ActiveMerchant::Billing::Response.new(
         gateway_response_success?,
@@ -23,107 +27,124 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
         gateway_response_params
       )
     end
+
     let(:gateway) { instance_double(SolidusAfterpay::Gateway, create_checkout: gateway_response) }
 
     before do
       allow(SolidusAfterpay::Gateway).to receive(:new).and_return(gateway)
     end
 
-    context 'with valid data' do
-      before do
-        allow(Spree::Order).to receive(:find_by!).with(number: order.number).and_return(order)
-        request
+    context 'when the user is logged in', with_signed_in_user: true do
+      context 'with valid data' do
+        before do
+          allow(Spree::Order).to receive(:find_by!).with(number: order.number).and_return(order)
+          request
+        end
+
+        it 'returns a 201 status code' do
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'returns the order_token' do
+          expect(JSON.parse(response.body)['token']).to eq(order_token)
+        end
+
+        it 'returns the correct params' do
+          expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
+        end
+
+        context 'when no redirect URLs are passed as params' do
+          let(:redirect_confirm_url) do
+            "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+          end
+
+          let(:redirect_cancel_url) do
+            "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+          end
+
+          it 'calls the create_checkout with the correct arguments' do
+            expect(gateway).to have_received(:create_checkout).with(
+              order,
+              redirect_confirm_url: redirect_confirm_url,
+              redirect_cancel_url: redirect_cancel_url
+            )
+          end
+        end
+
+        context 'when redirect URLs are passed as params' do
+          let(:redirect_confirm_url) { 'http://www.example.com/confirm_url' }
+          let(:redirect_cancel_url) { 'http://www.example.com/cancel_url' }
+
+          let(:params) do
+            { order_number: order_number, payment_method_id: payment_method_id,
+              redirect_confirm_url: redirect_confirm_url, redirect_cancel_url: redirect_cancel_url }
+          end
+
+          it 'calls the create_checkout with the correct arguments' do
+            expect(gateway).to have_received(:create_checkout).with(
+              order,
+              redirect_confirm_url: redirect_confirm_url,
+              redirect_cancel_url: redirect_cancel_url
+            )
+          end
+        end
       end
 
+      context 'when the order_number is invalid' do
+        let(:order_number) { 'INVALID_ORDER_NUMBER' }
+
+        before { request }
+
+        it 'returns a 404 status code' do
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns a resource not found error message' do
+          expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+        end
+      end
+
+      context 'when the payment_method_id is invalid' do
+        let(:payment_method_id) { 0 }
+
+        before { request }
+
+        it 'returns a 404 status code' do
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'returns a resource not found error message' do
+          expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+        end
+      end
+
+      context 'when the gateway responds with error' do
+        let(:gateway_response_success?) { false }
+        let(:gateway_response_message) { 'Error message' }
+
+        before { request }
+
+        it 'returns a 422 status code' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'returns a resource not found error message' do
+          expect(JSON.parse(response.body)['error']).to eq(gateway_response_message)
+        end
+      end
+    end
+
+    context 'when the user is a guest user', with_guest_session: true do
       it 'returns a 201 status code' do
+        request
         expect(response).to have_http_status(:created)
       end
-
-      it 'returns the order_token' do
-        expect(JSON.parse(response.body)['token']).to eq(order_token)
-      end
-
-      it 'returns the corrent params' do
-        expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
-      end
-
-      context 'when no redirect URLs are passed as params' do
-        let(:redirect_confirm_url) do
-          "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
-        end
-
-        let(:redirect_cancel_url) do
-          "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
-        end
-
-        it 'calls the create_checkout with the correct arguments' do
-          expect(gateway).to have_received(:create_checkout).with(
-            order,
-            redirect_confirm_url: redirect_confirm_url,
-            redirect_cancel_url: redirect_cancel_url
-          )
-        end
-      end
-
-      context 'when redirect URLs are passed as params' do
-        let(:redirect_confirm_url) { 'http://www.example.com/confirm_url' }
-        let(:redirect_cancel_url) { 'http://www.example.com/cancel_url' }
-
-        let(:params) do
-          { order_number: order_number, payment_method_id: payment_method_id,
-            redirect_confirm_url: redirect_confirm_url, redirect_cancel_url: redirect_cancel_url }
-        end
-
-        it 'calls the create_checkout with the correct arguments' do
-          expect(gateway).to have_received(:create_checkout).with(
-            order,
-            redirect_confirm_url: redirect_confirm_url,
-            redirect_cancel_url: redirect_cancel_url
-          )
-        end
-      end
     end
 
-    context 'when the order_number is invalid' do
-      let(:order_number) { 'INVALID_ORDER_NUMBER' }
-
-      before { request }
-
-      it 'returns a 404 status code' do
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it 'returns a resource not found error message' do
-        expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
-      end
-    end
-
-    context 'when the payment_method_id is invalid' do
-      let(:payment_method_id) { 0 }
-
-      before { request }
-
-      it 'returns a 404 status code' do
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it 'returns a resource not found error message' do
-        expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
-      end
-    end
-
-    context 'when the gateway responds with error' do
-      let(:gateway_response_success?) { false }
-      let(:gateway_response_message) { 'Error message' }
-
-      before { request }
-
-      it 'returns a 422 status code' do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'returns a resource not found error message' do
-        expect(JSON.parse(response.body)['error']).to eq(gateway_response_message)
+    context 'when the user is not logged in' do
+      it 'returns a 401 status code' do
+        request
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/support/auth.rb
+++ b/spec/support/auth.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
+  config.before(:each, with_signed_in_user: true) { login_as user }
+
+  config.before(:each, with_guest_session: true) do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ActionDispatch::Cookies::CookieJar).to(
+      receive(:signed).and_return({ guest_token: order.guest_token })
+    )
+    # rubocop:enable RSpec/AnyInstance
+  end
+end


### PR DESCRIPTION
This PR added the can can can authorization for the checkout and callbacks controller actions and they are needed to avoid security bug during the communication between Afterpay and Solidus.