### PR TITLE
 Introduce the use_solidus_api preference

### DIFF
--- a/app/controllers/solidus_afterpay/checkouts_controller.rb
+++ b/app/controllers/solidus_afterpay/checkouts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusAfterpay
-  class CheckoutsController < SolidusAfterpay::BaseController
+  class CheckoutsController < SolidusAfterpay.api_base_controller_parent_class
     def create
       authorize! :update, order, order_token
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "lib/generators/solidus_afterpay/install/templates"

--- a/lib/generators/solidus_afterpay/install/templates/initializer.rb
+++ b/lib/generators/solidus_afterpay/install/templates/initializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 SolidusAfterpay.configure do |config|
-  # TODO: Remember to change this with the actual preferences you have implemented!
-  # config.sample_preference = 'sample_value'
+  config.use_solidus_api = false
 end

--- a/lib/solidus_afterpay/configuration.rb
+++ b/lib/solidus_afterpay/configuration.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 module SolidusAfterpay
-  # rubocop:disable Lint/EmptyClass
   class Configuration
-    # Define here the settings for this extension, e.g.:
-    #
-    # attr_accessor :my_setting
+    attr_accessor :use_solidus_api
   end
-  # rubocop:enable Lint/EmptyClass
 
   class << self
     def configuration
@@ -18,6 +14,12 @@ module SolidusAfterpay
 
     def configure
       yield configuration
+    end
+
+    def api_base_controller_parent_class
+      return ::Spree::Api::BaseController if configuration.use_solidus_api
+
+      SolidusAfterpay::BaseController
     end
   end
 end

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 
 describe SolidusAfterpay::CheckoutsController, type: :request do
   describe 'POST create' do
-    subject(:request) { post '/solidus_afterpay/checkouts.json', params: params }
+    subject(:request) { post '/solidus_afterpay/checkouts.json', params: params, headers: headers }
 
     let(:order) { create(:order_with_totals, state: 'payment', user: user) }
     let(:payment_method) { create(:afterpay_payment_method) }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :with_api_key) }
 
     let(:order_number) { order.number }
     let(:payment_method_id) { payment_method.id }
@@ -19,6 +19,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
     let(:gateway_response_success?) { true }
     let(:gateway_response_message) { 'Success message' }
     let(:gateway_response_params) { { 'token' => order_token } }
+    let(:headers) { {} }
 
     let(:gateway_response) do
       ActiveMerchant::Billing::Response.new(
@@ -34,117 +35,148 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
       allow(SolidusAfterpay::Gateway).to receive(:new).and_return(gateway)
     end
 
-    context 'when the user is logged in', with_signed_in_user: true do
-      context 'with valid data' do
-        before do
-          allow(Spree::Order).to receive(:find_by!).with(number: order.number).and_return(order)
-          request
+    context 'when the use solidus api config is set to false' do
+      context 'when the user is logged in', with_signed_in_user: true do
+        context 'with valid data' do
+          before do
+            allow(Spree::Order).to receive(:find_by!).with(number: order.number).and_return(order)
+            request
+          end
+
+          it 'returns a 201 status code' do
+            expect(response).to have_http_status(:created)
+          end
+
+          it 'returns the order_token' do
+            expect(JSON.parse(response.body)['token']).to eq(order_token)
+          end
+
+          it 'returns the correct params' do
+            expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
+          end
+
+          context 'when no redirect URLs are passed as params' do
+            let(:redirect_confirm_url) do
+              "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+            end
+
+            let(:redirect_cancel_url) do
+              "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+            end
+
+            it 'calls the create_checkout with the correct arguments' do
+              expect(gateway).to have_received(:create_checkout).with(
+                order,
+                redirect_confirm_url: redirect_confirm_url,
+                redirect_cancel_url: redirect_cancel_url
+              )
+            end
+          end
+
+          context 'when redirect URLs are passed as params' do
+            let(:redirect_confirm_url) { 'http://www.example.com/confirm_url' }
+            let(:redirect_cancel_url) { 'http://www.example.com/cancel_url' }
+
+            let(:params) do
+              { order_number: order_number, payment_method_id: payment_method_id,
+                redirect_confirm_url: redirect_confirm_url, redirect_cancel_url: redirect_cancel_url }
+            end
+
+            it 'calls the create_checkout with the correct arguments' do
+              expect(gateway).to have_received(:create_checkout).with(
+                order,
+                redirect_confirm_url: redirect_confirm_url,
+                redirect_cancel_url: redirect_cancel_url
+              )
+            end
+          end
         end
 
+        context 'when the order_number is invalid' do
+          let(:order_number) { 'INVALID_ORDER_NUMBER' }
+
+          before { request }
+
+          it 'returns a 404 status code' do
+            expect(response).to have_http_status(:not_found)
+          end
+
+          it 'returns a resource not found error message' do
+            expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+          end
+        end
+
+        context 'when the payment_method_id is invalid' do
+          let(:payment_method_id) { 0 }
+
+          before { request }
+
+          it 'returns a 404 status code' do
+            expect(response).to have_http_status(:not_found)
+          end
+
+          it 'returns a resource not found error message' do
+            expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+          end
+        end
+
+        context 'when the gateway responds with error' do
+          let(:gateway_response_success?) { false }
+          let(:gateway_response_message) { 'Error message' }
+
+          before { request }
+
+          it 'returns a 422 status code' do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'returns a resource not found error message' do
+            expect(JSON.parse(response.body)['error']).to eq(gateway_response_message)
+          end
+        end
+      end
+
+      context 'when the user is a guest user', with_guest_session: true do
         it 'returns a 201 status code' do
+          request
           expect(response).to have_http_status(:created)
         end
-
-        it 'returns the order_token' do
-          expect(JSON.parse(response.body)['token']).to eq(order_token)
-        end
-
-        it 'returns the correct params' do
-          expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
-        end
-
-        context 'when no redirect URLs are passed as params' do
-          let(:redirect_confirm_url) do
-            "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
-          end
-
-          let(:redirect_cancel_url) do
-            "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
-          end
-
-          it 'calls the create_checkout with the correct arguments' do
-            expect(gateway).to have_received(:create_checkout).with(
-              order,
-              redirect_confirm_url: redirect_confirm_url,
-              redirect_cancel_url: redirect_cancel_url
-            )
-          end
-        end
-
-        context 'when redirect URLs are passed as params' do
-          let(:redirect_confirm_url) { 'http://www.example.com/confirm_url' }
-          let(:redirect_cancel_url) { 'http://www.example.com/cancel_url' }
-
-          let(:params) do
-            { order_number: order_number, payment_method_id: payment_method_id,
-              redirect_confirm_url: redirect_confirm_url, redirect_cancel_url: redirect_cancel_url }
-          end
-
-          it 'calls the create_checkout with the correct arguments' do
-            expect(gateway).to have_received(:create_checkout).with(
-              order,
-              redirect_confirm_url: redirect_confirm_url,
-              redirect_cancel_url: redirect_cancel_url
-            )
-          end
-        end
       end
 
-      context 'when the order_number is invalid' do
-        let(:order_number) { 'INVALID_ORDER_NUMBER' }
-
-        before { request }
-
-        it 'returns a 404 status code' do
-          expect(response).to have_http_status(:not_found)
-        end
-
-        it 'returns a resource not found error message' do
-          expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
-        end
-      end
-
-      context 'when the payment_method_id is invalid' do
-        let(:payment_method_id) { 0 }
-
-        before { request }
-
-        it 'returns a 404 status code' do
-          expect(response).to have_http_status(:not_found)
-        end
-
-        it 'returns a resource not found error message' do
-          expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
-        end
-      end
-
-      context 'when the gateway responds with error' do
-        let(:gateway_response_success?) { false }
-        let(:gateway_response_message) { 'Error message' }
-
-        before { request }
-
-        it 'returns a 422 status code' do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-
-        it 'returns a resource not found error message' do
-          expect(JSON.parse(response.body)['error']).to eq(gateway_response_message)
+      context 'when the user is not logged in' do
+        it 'returns a 401 status code' do
+          request
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
 
-    context 'when the user is a guest user', with_guest_session: true do
-      it 'returns a 201 status code' do
-        request
-        expect(response).to have_http_status(:created)
-      end
-    end
+    context 'when the use solidus api config is set to true', use_solidus_api: true do
+      context 'when the user is logged in' do
+        let(:headers) { { Authorization: "Bearer #{user.spree_api_key}" } }
 
-    context 'when the user is not logged in' do
-      it 'returns a 401 status code' do
-        request
-        expect(response).to have_http_status(:unauthorized)
+        it 'returns a 201 status code' do
+          request
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context 'when the user is a guest user' do
+        let(:headers) { { 'X-Spree-Order-Token': order.guest_token } }
+
+        it 'returns a 201 status code' do
+          request
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context 'when the user is not logged in' do
+        let(:headers) { { Authorization: 'Bearer 1234' } }
+
+        it 'returns a 401 status code' do
+          request
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
   end

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  def described_class_source_location
+    described_class.instance_methods(false).map do |method|
+      described_class.instance_method(method).source_location.first
+    end.uniq.first
+  end
+
+  config.before(:each, use_solidus_api: true) do
+    SolidusAfterpay.configure do |c|
+      c.use_solidus_api = true
+    end
+
+    class_name = described_class.to_s.split('::').last
+    source_location = described_class_source_location
+
+    SolidusAfterpay.send(:remove_const, class_name)
+    load source_location
+  end
+
+  config.after(:each, use_solidus_api: true) do
+    SolidusAfterpay.configure do |c|
+      c.use_solidus_api = false
+    end
+
+    class_name = described_class.to_s.split('::').last
+    source_location = described_class_source_location
+
+    SolidusAfterpay.send(:remove_const, class_name)
+    load source_location
+  end
+end


### PR DESCRIPTION
Until now the `SolidusAfterpay::Api::CheckoutsController` only handles a cookie-based authentication.
If a store wants to use an API-based authentication, it can set the `use_solidus_api` preference to `true`.
Under the hood that preference changes the parent class of the controller from `SolidusAfterpay::BaseController` to `::Spree::Api::BaseController`.