### PR TITLE
Small changes for the CheckoutsController

### DIFF
--- a/app/controllers/solidus_afterpay/checkouts_controller.rb
+++ b/app/controllers/solidus_afterpay/checkouts_controller.rb
@@ -9,12 +9,8 @@ module SolidusAfterpay
     def create
       response = payment_method.gateway.create_checkout(
         order,
-        redirect_confirm_url: solidus_afterpay.callbacks_confirm_url(
-          order_number: order.number, payment_method_id: payment_method.id
-        ),
-        redirect_cancel_url: solidus_afterpay.callbacks_cancel_url(
-          order_number: order.number, payment_method_id: payment_method.id
-        )
+        redirect_confirm_url: redirect_confirm_url,
+        redirect_cancel_url: redirect_cancel_url
       )
 
       if response.success?
@@ -36,6 +32,18 @@ module SolidusAfterpay
 
     def payment_method
       @payment_method ||= SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
+    end
+
+    def redirect_confirm_url
+      params[:redirect_confirm_url] || solidus_afterpay.callbacks_confirm_url(
+        order_number: order.number, payment_method_id: payment_method.id
+      )
+    end
+
+    def redirect_cancel_url
+      params[:redirect_cancel_url] || solidus_afterpay.callbacks_cancel_url(
+        order_number: order.number, payment_method_id: payment_method.id
+      )
     end
 
     def resource_not_found

--- a/app/controllers/solidus_afterpay/checkouts_controller.rb
+++ b/app/controllers/solidus_afterpay/checkouts_controller.rb
@@ -16,8 +16,13 @@ module SolidusAfterpay
           order_number: order.number, payment_method_id: payment_method.id
         )
       )
+
       if response.success?
-        render json: { token: response.params['token'] }
+        render json: {
+          token: response.params['token'],
+          expires: response.params['expires'],
+          redirectCheckoutUrl: response.params['redirectCheckoutUrl']
+        }
       else
         render json: { error: response.message }, status: :internal_server_error
       end

--- a/app/controllers/solidus_afterpay/checkouts_controller.rb
+++ b/app/controllers/solidus_afterpay/checkouts_controller.rb
@@ -22,9 +22,9 @@ module SolidusAfterpay
           token: response.params['token'],
           expires: response.params['expires'],
           redirectCheckoutUrl: response.params['redirectCheckoutUrl']
-        }
+        }, status: :created
       else
-        render json: { error: response.message }, status: :internal_server_error
+        render json: { error: response.message }, status: :unprocessable_entity
       end
     end
 

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -43,8 +43,8 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
         )
       end
 
-      it 'returns a 200 status code' do
-        expect(response).to have_http_status(:ok)
+      it 'returns a 201 status code' do
+        expect(response).to have_http_status(:created)
       end
 
       it 'returns the order_token' do
@@ -90,8 +90,8 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
 
       before { request }
 
-      it 'returns a 500 status code' do
-        expect(response).to have_http_status(:internal_server_error)
+      it 'returns a 422 status code' do
+        expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'returns a resource not found error message' do

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -35,14 +35,6 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
         request
       end
 
-      it 'calls the create_checkout with the correct arguments' do
-        expect(gateway).to have_received(:create_checkout).with(
-          order,
-          redirect_confirm_url: "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}",
-          redirect_cancel_url: "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
-        )
-      end
-
       it 'returns a 201 status code' do
         expect(response).to have_http_status(:created)
       end
@@ -53,6 +45,42 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
 
       it 'returns the corrent params' do
         expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
+      end
+
+      context 'when no redirect URLs are passed as params' do
+        let(:redirect_confirm_url) do
+          "http://www.example.com/solidus_afterpay/callbacks/confirm?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+        end
+
+        let(:redirect_cancel_url) do
+          "http://www.example.com/solidus_afterpay/callbacks/cancel?order_number=#{order.number}&payment_method_id=#{payment_method.id}"
+        end
+
+        it 'calls the create_checkout with the correct arguments' do
+          expect(gateway).to have_received(:create_checkout).with(
+            order,
+            redirect_confirm_url: redirect_confirm_url,
+            redirect_cancel_url: redirect_cancel_url
+          )
+        end
+      end
+
+      context 'when redirect URLs are passed as params' do
+        let(:redirect_confirm_url) { 'http://www.example.com/confirm_url' }
+        let(:redirect_cancel_url) { 'http://www.example.com/cancel_url' }
+
+        let(:params) do
+          { order_number: order_number, payment_method_id: payment_method_id,
+            redirect_confirm_url: redirect_confirm_url, redirect_cancel_url: redirect_cancel_url }
+        end
+
+        it 'calls the create_checkout with the correct arguments' do
+          expect(gateway).to have_received(:create_checkout).with(
+            order,
+            redirect_confirm_url: redirect_confirm_url,
+            redirect_cancel_url: redirect_cancel_url
+          )
+        end
       end
     end
 

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -50,6 +50,10 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
       it 'returns the order_token' do
         expect(JSON.parse(response.body)['token']).to eq(order_token)
       end
+
+      it 'returns the corrent params' do
+        expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
+      end
     end
 
     context 'when the order_number is invalid' do


### PR DESCRIPTION
This PR contains a set of small changes for the CheckoutsController

- Allow to pass custom redirect URLs to CheckoutsController
- Change return status codes to match Afterpay in the CheckoutController
- Return the same field as Afterpay in the CheckoutsController