### PR TITLE
Min max preferred amount

### DIFF
--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -40,18 +40,41 @@ module SolidusAfterpay
     private
 
     def available_payment_range
-      min = preferred_minimum_amount || configuration&.minimumAmount&.amount.to_f
-      max = preferred_maximum_amount || configuration&.maximumAmount&.amount.to_f
-
-      min..max
-    end
-
-    def available_payment_currency
-      preferred_currency || configuration&.maximumAmount&.currency
+      minimum_amount..maximum_amount
     end
 
     def configuration
       @configuration ||= gateway.retrieve_configuration
+    end
+
+    def minimum_amount
+      @minimum_amount ||= fetch_configuration(:minimumAmount, :amount).to_f
+    end
+
+    def maximum_amount
+      @maximum_amount ||= fetch_configuration(:maximumAmount, :amount).to_f
+    end
+
+    def available_payment_currency
+      @available_payment_currency = fetch_configuration(:maximumAmount, :currency)
+    end
+
+    def fetch_configuration(*keys)
+      cache_key = "solidus_afterpay_configuration_#{keys.join('_')}"
+
+      return Rails.cache.read(cache_key) if Rails.cache.exist?(cache_key)
+
+      value = configuration&.dig(*keys)
+
+      unless configuration.nil?
+        Rails.cache.write(
+          cache_key,
+          value,
+          expires_in: SolidusAfterpay.config.cache_expiry
+        )
+      end
+
+      value
     end
   end
 end

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -6,9 +6,6 @@ module SolidusAfterpay
     preference :secret_key, :string
     preference :deferred, :boolean
     preference :popup_window, :boolean
-    preference :minimum_amount, :decimal
-    preference :maximum_amount, :decimal
-    preference :currency, :string
     preference :merchant_key, :string
 
     def gateway_class

--- a/lib/generators/solidus_afterpay/install/templates/initializer.rb
+++ b/lib/generators/solidus_afterpay/install/templates/initializer.rb
@@ -2,7 +2,6 @@
 
 SolidusAfterpay.configure do |config|
   config.use_solidus_api = false
-
   # A class that extend SolidusAfterpay::BaseService, respond to .call, accepting a Spree::Order
   # and return an Afterpay shipping rate object (check the Afterpay documentation)
   # config.shipping_rate_builder_service_class = 'SolidusAfterpay::ShippingRateBuilderService'
@@ -10,4 +9,9 @@ SolidusAfterpay.configure do |config|
   # A class that extend SolidusAfterpay::BaseService, respond to .call, accepting a Spree::Order
   # and return true or false
   # config.update_order_attributes_service_class = 'SolidusAfterpay::UpdateOrderAttributesService'
+
+  # There is a cache for retrieving the minimum amount, maximum amount and the currency from Afterpay
+  # the default value us set to 1.day, this is also recommended by Afterpay itself. If you prefer a shorter
+  # or longer time simply uncomment config.cache_expiry and add the preferred value.
+  # config.cache_expiry = 1.day
 end

--- a/lib/solidus_afterpay/configuration.rb
+++ b/lib/solidus_afterpay/configuration.rb
@@ -3,7 +3,7 @@
 module SolidusAfterpay
   class Configuration
     attr_accessor :use_solidus_api
-    attr_writer :shipping_rate_builder_service_class
+    attr_writer :shipping_rate_builder_service_class, :cache_expiry
 
     def dummy_email
       'afterpay@dummy.com'
@@ -17,6 +17,10 @@ module SolidusAfterpay
     def update_order_attributes_service_class
       @update_order_attributes_service_class ||= 'SolidusAfterpay::UpdateOrderAttributesService'
       @update_order_attributes_service_class.constantize
+    end
+
+    def cache_expiry
+      @cache_expiry ||= 1.day
     end
   end
 


### PR DESCRIPTION
# Min/Max Amount Bug Fix

Add cache methods for currency, minimum and maximum amount values when fetching this data from Afterpay with an expiry value of 1 day as this will slow down the performance of every user that tries to checkout have to make an API call.

fix #18 