### PR TITLE
Use auto_capture instead of deferred boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ SolidusAfterpay::PaymentMethod.new(
 
 This flow completes the payment approval and starts the consumer's payment plan, but does not initiate the settlement process. This flow allows settlement of merchant funds to be deferred until order fulfilment can be confirmed.
 
-Simply check the deferred checkbox when creating the Afterpay payment_method to activate the deferred payment flow instead of the immediate payment flow.
+Simply set the auto_capture to false when creating the Afterpay payment_method to activate the deferred payment flow instead of the immediate payment flow.
 
 For more info about the deferred payment flow click [here](https://developers.afterpay.com/afterpay-online/reference#deferred-payment-flow).
 

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -4,7 +4,6 @@ module SolidusAfterpay
   class PaymentMethod < SolidusSupport.payment_method_parent_class
     preference :merchant_id, :string
     preference :secret_key, :string
-    preference :deferred, :boolean
     preference :popup_window, :boolean
     preference :merchant_key, :string
 

--- a/app/models/solidus_afterpay/payment_source.rb
+++ b/app/models/solidus_afterpay/payment_source.rb
@@ -13,7 +13,7 @@ module SolidusAfterpay
     def can_void?(payment)
       payment_method = payment.payment_method
 
-      return false unless payment_method.preferred_deferred
+      return false if payment_method.auto_capture
 
       payment_state = payment_method.gateway.find_payment(order_id: payment.response_code).try(:[], :paymentState)
 

--- a/spec/models/solidus_afterpay/gateway_spec.rb
+++ b/spec/models/solidus_afterpay/gateway_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe SolidusAfterpay::Gateway do
     subject(:response) { gateway.authorize(amount, payment_source, gateway_options) }
 
     let(:order_token) { '002.m6d9jkrtv1p0j4jqslklhfq9k4nl54jo2530d58kf6snpqq1' }
-    let(:deferred?) { false }
-    let(:payment_method) { build(:afterpay_payment_method, preferred_deferred: deferred?) }
+    let(:auto_capture) { true }
+    let(:payment_method) { build(:afterpay_payment_method, auto_capture: auto_capture) }
 
     let(:amount) { 1000 }
     let(:payment_source) { build(:afterpay_payment_source, token: order_token, payment_method: payment_method) }
@@ -30,7 +30,7 @@ RSpec.describe SolidusAfterpay::Gateway do
     end
 
     context 'with the deferred flow' do
-      let(:deferred?) { true }
+      let(:auto_capture) { false }
 
       context 'with valid params', vcr: 'deferred/authorize/valid' do
         it 'authorize the afterpay payment with the order_token' do
@@ -78,9 +78,9 @@ RSpec.describe SolidusAfterpay::Gateway do
     subject(:response) { gateway.capture(amount, response_code, gateway_options) }
 
     let(:order_token) { '002.nt7e0ioqj00fh0ua1nbqcj6vcn9obtfsglqvrj9ijpo3edfc' }
-    let(:deferred?) { false }
+    let(:auto_capture) { true }
     let(:payment_source) { build(:afterpay_payment_source, token: order_token) }
-    let(:payment_method) { build(:afterpay_payment_method, preferred_deferred: deferred?) }
+    let(:payment_method) { build(:afterpay_payment_method, auto_capture: auto_capture) }
     let(:payment) { build(:afterpay_payment, source: payment_source, payment_method: payment_method) }
 
     let(:amount) { 1000 }
@@ -130,7 +130,7 @@ RSpec.describe SolidusAfterpay::Gateway do
     end
 
     context 'with the deferred flow' do
-      let(:deferred?) { true }
+      let(:auto_capture) { false }
 
       context 'with valid params', vcr: 'deferred/capture/valid' do
         it 'captures the afterpay payment with the order_id' do
@@ -160,8 +160,8 @@ RSpec.describe SolidusAfterpay::Gateway do
     subject(:response) { gateway.purchase(amount, payment_source, gateway_options) }
 
     let(:order_token) { '002.nt7e0ioqj00fh0ua1nbqcj6vcn9obtfsglqvrj9ijpo3edfc' }
-    let(:deferred?) { false }
-    let(:payment_method) { build(:afterpay_payment_method, preferred_deferred: deferred?) }
+    let(:auto_capture) { true }
+    let(:payment_method) { build(:afterpay_payment_method, auto_capture: auto_capture) }
     let(:payment) { build(:afterpay_payment, source: payment_source, payment_method: payment_method) }
 
     let(:amount) { 1000 }
@@ -211,7 +211,7 @@ RSpec.describe SolidusAfterpay::Gateway do
     end
 
     context 'with the deferred flow' do
-      let(:deferred?) { true }
+      let(:auto_capture) { false }
 
       context 'with valid params', vcr: 'deferred/authorize/valid' do
         it 'authorize and captures the afterpay payment with the order_token' do
@@ -293,9 +293,9 @@ RSpec.describe SolidusAfterpay::Gateway do
   describe '#void' do
     subject(:response) { gateway.void(response_code, gateway_options) }
 
-    let(:deferred?) { false }
+    let(:auto_capture) { true }
     let(:amount) { 10 }
-    let(:payment_method) { build(:afterpay_payment_method, preferred_deferred: deferred?) }
+    let(:payment_method) { build(:afterpay_payment_method, auto_capture: auto_capture) }
     let(:payment) { build(:afterpay_payment, payment_method: payment_method, amount: amount) }
 
     let(:response_code) { '100101785223' }
@@ -316,7 +316,7 @@ RSpec.describe SolidusAfterpay::Gateway do
     end
 
     context 'with the deferred flow' do
-      let(:deferred?) { true }
+      let(:auto_capture) { false }
 
       context 'with valid params', vcr: 'deferred/void/valid' do
         it 'voids the payment using the response_code' do

--- a/spec/models/solidus_afterpay/payment_source_spec.rb
+++ b/spec/models/solidus_afterpay/payment_source_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe SolidusAfterpay::PaymentSource, type: :model do
   describe '#can_void?' do
     subject { payment_source.can_void?(payment) }
 
-    let(:deferred?) { false }
-    let(:payment_method) { build(:afterpay_payment_method, preferred_deferred: deferred?) }
+    let(:auto_capture) { true }
+    let(:payment_method) { build(:afterpay_payment_method, auto_capture: auto_capture) }
     let(:payment) { build(:afterpay_payment, payment_method: payment_method) }
 
     context 'with the immediate flow' do
@@ -25,7 +25,7 @@ RSpec.describe SolidusAfterpay::PaymentSource, type: :model do
     end
 
     context 'with the deferred flow' do
-      let(:deferred?) { true }
+      let(:auto_capture) { false }
 
       let(:payment_state) { 'AUTH_APPROVED' }
       let(:gateway_response) { { paymentState: payment_state } }


### PR DESCRIPTION
# AutoCapture Instead of Deferred Flag

As the deferred payment_flow is exactly the same like
setting the auto_capture on solidus to false, I removed
the deferred flag and use the auto_capture instead for 
choosing whether to use the deferred or immediate 
payment flow.