### PR TITLE
Exclude products from afterpay

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Afterpay offers an on-site messaging component to notify the customer that there
 
 To add the `Afterpay messaging` simply add the `Afterpay messaging partial` into your `html.erb` file, like this.
 
+You need to provide the product as well, so you can exclude products from `Afterpay messaging`.
+
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
 ```
 
 The amount, locale and currency are required in order to work properly.
@@ -114,7 +116,7 @@ The min attribute is to configure from which amount Afterpay should be available
 For example if you would write...
 
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: 25, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: 25, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
 ```
 
 And a product price is `28.99`, Afterpay will display on that product that Afterpay is only available for orders between 1$ and 25$.
@@ -128,7 +130,7 @@ Click [here](https://developers.afterpay.com/afterpay-online/docs/advanced-usage
 If you would like to change the size of the Afterpay messaging you simply add size to the `data` hash. For example...
 
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, data: { amount: <Product price>, locale: "en_US", currency: "USD", size: "sm" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD", size: "sm" } %>
 ```
 
 ## Development

--- a/app/assets/javascripts/solidus_afterpay/backend/afterpay_autocomplete.js
+++ b/app/assets/javascripts/solidus_afterpay/backend/afterpay_autocomplete.js
@@ -1,0 +1,9 @@
+Spree.ready(function () {
+  if (
+    $(
+      'form#edit_payment_method option[value="SolidusAfterpay::PaymentMethod"]:selected'
+    ).length > 0
+  ) {
+    $("#payment_method_preferred_excluded_products").productAutocomplete();
+  }
+});

--- a/app/assets/javascripts/spree/backend/solidus_afterpay.js
+++ b/app/assets/javascripts/spree/backend/solidus_afterpay.js
@@ -1,2 +1,4 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+
+//= require solidus_afterpay/backend/afterpay_autocomplete

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -6,6 +6,7 @@ module SolidusAfterpay
     preference :secret_key, :string
     preference :popup_window, :boolean
     preference :merchant_key, :string
+    preference :excluded_products, :string
 
     def gateway_class
       SolidusAfterpay::Gateway
@@ -30,10 +31,18 @@ module SolidusAfterpay
     end
 
     def available_for_order?(order)
+      return false if order.line_items.any?{ |item| excluded_product_ids.include? item.variant.product_id }
+
       available_payment_currency == order.currency && available_payment_range.include?(order.total)
     end
 
     private
+
+    def excluded_product_ids
+      return [] if preferred_excluded_products.nil?
+
+      preferred_excluded_products.split(",").map(&:to_i)
+    end
 
     def available_payment_range
       minimum_amount..maximum_amount

--- a/app/models/solidus_afterpay/payment_method.rb
+++ b/app/models/solidus_afterpay/payment_method.rb
@@ -36,6 +36,10 @@ module SolidusAfterpay
       available_payment_currency == order.currency && available_payment_range.include?(order.total)
     end
 
+    def excluded_product?(product)
+      excluded_product_ids.include? product.id
+    end
+
     private
 
     def excluded_product_ids

--- a/app/views/spree/shared/_afterpay_messaging.html.erb
+++ b/app/views/spree/shared/_afterpay_messaging.html.erb
@@ -1,13 +1,15 @@
-<% content_for :head do %>
-  <script
-    src="https://js.afterpay.com/afterpay-1.x.js"
-    data-analytics-enabled
-    async
-    <% if max %>
-    data-min="<%= min %>"
-    data-max="<%= max %>"
-    <% end %>
-  ></script>
-<% end %>
+<% unless ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) %>
+  <% content_for :head do %>
+    <script
+      src="https://js.afterpay.com/afterpay-1.x.js"
+      data-analytics-enabled
+      async
+      <% if max %>
+      data-min="<%= min %>"
+      data-max="<%= max %>"
+      <% end %>
+    ></script>
+  <% end %>
 
-<%= content_tag("afterpay-placement", nil, data: data) %>
+  <%= content_tag("afterpay-placement", nil, data: data) %>
+<% end %>

--- a/spec/models/solidus_afterpay/payment_method_spec.rb
+++ b/spec/models/solidus_afterpay/payment_method_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe SolidusAfterpay::PaymentMethod, type: :model do
     end
   end
 
+  describe "#excluded_product?" do
+    subject { payment_method.excluded_product?(product) }
+
+    let(:product) { create(:base_product) }
+    let(:excluded_product_ids) { product.id.to_s }
+    let(:payment_method) { described_class.new(preferred_excluded_products: excluded_product_ids) }
+
+    context 'when the product is excluded' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the product is not excluded' do
+      let(:excluded_product_ids) { '' }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe "#available_for_order?" do
     subject { payment_method.available_for_order?(order) }
 

--- a/spec/support/cache.rb
+++ b/spec/support/cache.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.after { Rails.cache.clear }
+end


### PR DESCRIPTION
# Excluded Products for Afterpay

Add feature to exclude products for Afterpay, so that the admin is able to exclude any product he wants. By adding the Product ID in the payment method settings, using an autocomplete.