### PR TITLE
Fix afterpay partial bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ If you want to override this logic, adding/removing attributes, you can provide 
 ### Express checkout from the cart
 
 An Afterpay button can also be included on the cart view to enable express checkouts:
+> Products should always be an array! Even for a single item.
 
 ```ruby
-render "solidus_afterpay/afterpay_checkout_button"
+<%= render "solidus_afterpay/afterpay_checkout_button", products: [<product>] %>
 ```
 
 ### Afterpay Messaging
@@ -99,10 +100,13 @@ Afterpay offers an on-site messaging component to notify the customer that there
 
 To add the `Afterpay messaging` simply add the `Afterpay messaging partial` into your `html.erb` file, like this.
 
-You need to provide the product as well, so you can exclude products from `Afterpay messaging`.
+You need to provide the products as well, so you can exclude products from `Afterpay messaging`. It is required to
+add the product in an array for example: `products: [<product>]`, or for multiple products: `products: [<product1>, <product2>]`.
+
+If you only have the order you can do it like this `products: order.line_items.map { |item| item.variant.product }`.
 
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, products: [<Product>], data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
 ```
 
 The amount, locale and currency are required in order to work properly.
@@ -116,7 +120,7 @@ The min attribute is to configure from which amount Afterpay should be available
 For example if you would write...
 
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: 25, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: 25, products: [<Product>], data: { amount: <Product price>, locale: "en_US", currency: "USD" } %>
 ```
 
 And a product price is `28.99`, Afterpay will display on that product that Afterpay is only available for orders between 1$ and 25$.
@@ -130,7 +134,7 @@ Click [here](https://developers.afterpay.com/afterpay-online/docs/advanced-usage
 If you would like to change the size of the Afterpay messaging you simply add size to the `data` hash. For example...
 
 ```erb
-<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, product: <Product>, data: { amount: <Product price>, locale: "en_US", currency: "USD", size: "sm" } %>
+<%= render "spree/shared/afterpay_messaging", min: nil, max: nil, product: [<Product>], data: { amount: <Product price>, locale: "en_US", currency: "USD", size: "sm" } %>
 ```
 
 ## Development

--- a/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
+++ b/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
@@ -1,6 +1,6 @@
 <% payment_method = SolidusAfterpay::PaymentMethod.active.first unless local_assigns[:payment_method] %>
 
-<%= render partial: 'solidus_afterpay/afterpay_javascript', locals: { payment_method: payment_method } %>
+<%= render partial: 'solidus_afterpay/afterpay_javascript', locals: { payment_method: payment_method } if Rails.env != "test" %>
 
 <% if payment_method.present? && products.none? { |product| ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) }  %>
   <button type="button" id="afterpay-button" data-afterpay-entry-point="cart" data-order-number="<%= @order.number %>" data-payment-method-id="<%= payment_method.id %>">

--- a/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
+++ b/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'solidus_afterpay/afterpay_javascript', locals: { payment_method: payment_method } %>
 
-<% if payment_method.present? %>
+<% if payment_method.present? && products.none? { |product| ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) }  %>
   <button type="button" id="afterpay-button" data-afterpay-entry-point="cart" data-order-number="<%= @order.number %>" data-payment-method-id="<%= payment_method.id %>">
     <%= I18n.t('solidus_afterpay.express_checkout.button') %>
   </button>

--- a/app/views/spree/shared/_afterpay_messaging.html.erb
+++ b/app/views/spree/shared/_afterpay_messaging.html.erb
@@ -1,4 +1,4 @@
-<% unless ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) %>
+<% if products.none? { |product| ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) } %>
   <% content_for :head do %>
     <script
       src="https://js.afterpay.com/afterpay-1.x.js"

--- a/spec/views/solidus_afterpay/express_checkout_button_spec.rb
+++ b/spec/views/solidus_afterpay/express_checkout_button_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe "rendering afterpay express checkout button", type: :view do
+  let(:product) { create(:base_product) }
+  let(:second_product) { create(:base_product) }
+  let(:excluded_product) { create(:base_product) }
+  let(:payment_method) { SolidusAfterpay::PaymentMethod.active.first }
+  let(:amount) { product.price }
+  let(:product_array) { [product] }
+
+  before do
+    create(:afterpay_payment_method, preferred_excluded_products: excluded_product.id.to_s)
+    assign(:order, create(:order))
+    render "solidus_afterpay/afterpay_checkout_button", products: product_array
+  end
+
+  context "when rendering afterpay express checkout button for a single product" do
+    it 'displays the afterpay express checkout button' do
+      expect(rendered).to match("Checkout with Afterpay")
+    end
+  end
+
+  context "when rendering afterpay express checkout button for multiple products" do
+    let(:product_array) { [product, second_product] }
+
+    it 'displays the afterpay express checkout button' do
+      expect(rendered).to match("Checkout with Afterpay")
+    end
+  end
+
+  context "when rendering afterpay express checkout button with an excluded product" do
+    let(:product_array) { [product, second_product, excluded_product] }
+
+    it 'does not display the afterpay express checkout button' do
+      expect(rendered).not_to match("Checkout with Afterpay")
+    end
+  end
+end

--- a/spec/views/spree/shared/afterpay_messaging_spec.rb
+++ b/spec/views/spree/shared/afterpay_messaging_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe "rendering afterpay messaging", type: :view do
+  let(:product) { create(:base_product) }
+  let(:second_product) { create(:base_product) }
+  let(:excluded_product) { create(:base_product) }
+  let(:product_array) { [product] }
+  let(:payment_method) { SolidusAfterpay::PaymentMethod.active.first }
+  let(:amount) { product.price }
+
+  before do
+    create(:afterpay_payment_method, preferred_excluded_products: excluded_product.id.to_s)
+    render partial: "spree/shared/afterpay_messaging", locals: { min: nil, max: nil, products: product_array,
+                                                                 data:
+                                                                 { amount: amount, locale: "en_US", currency: "USD" } }
+  end
+
+  context "without excluded products" do
+    context "when rendering afterpay messaging for a single product" do
+      it 'displays afterpay messaging' do
+        expect(rendered).to match("19.99" && "afterpay-placement")
+      end
+    end
+
+    context "when rendering afterpay messaging for multiple products" do
+      let(:product_array) { [product, second_product] }
+      let(:amount) { (product.price + second_product.price) }
+
+      it 'displays afterpay messaging' do
+        expect(rendered).to match("39.98" && "afterpay-placement")
+      end
+    end
+  end
+
+  context "with excluded products" do
+    context "when one of the products is excluded" do
+      let(:product_array) { [product, second_product, excluded_product] }
+
+      it "does not render the afterpay messaging partial" do
+        expect(rendered).not_to match("afterpay-placement")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Fix Afterpay Partial Bug

Before, the partial was only taking a single product for excluding products, but when on the cart page, there could be multiple items, and the partial could not handle this. Now it is more generic by using an array instead.

Add if statement for the Javascript rendering partial to not render in test mode as the tests weren’t able to run with this partial.