### PR TITLE
Add estimated shipment date to component builder

### DIFF
--- a/lib/solidus_afterpay/testing_support/factories.rb
+++ b/lib/solidus_afterpay/testing_support/factories.rb
@@ -18,3 +18,23 @@ FactoryBot.define do
     token { "12345678910" }
   end
 end
+
+FactoryBot.define do
+  factory :order_with_variant_property, class: "Spree::Order", parent: :order_with_line_items do
+    after(:build) do |order|
+      variant_property_rule_value = create(:variant_property_rule_value, value: "2021-09-19",
+property: create(:property, name: "estimatedShipmentDate"))
+      order.line_items.first.variant.product.variant_property_rules << variant_property_rule_value.variant_property_rule
+      order.line_items.first.variant.option_values << variant_property_rule_value.variant_property_rule
+                                                                                 .option_values.first
+    end
+  end
+end
+
+FactoryBot.define do
+  factory :order_with_product_property, class: "Spree::Order", parent: :order_with_line_items do
+    after(:build) do |order|
+      order.line_items.first.product.set_property("estimatedShipmentDate", "2025-10-25")
+    end
+  end
+end

--- a/solidus_afterpay.gemspec
+++ b/solidus_afterpay.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'afterpay', '~> 0.2.0'
+  spec.add_dependency 'afterpay', '~> 0.3.0'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
# Estimated Shipment Date

This is needed when provided a property type set to
`estimatedShipmentDate`, to send the correct data to `Afterpay`.

It will first look for the variant property type, and if not found, it will look for the product property type, 
like this, you can either put it on the whole item or just the variant or even for the entire product but with one exception variant.

Co-authored-by: MassimilianoLattanzio massimiliano.lattanzio@gmail.com