### PR TITLE
Add the reversal payment endpoint on error

### DIFF
--- a/app/models/solidus_afterpay/gateway.rb
+++ b/app/models/solidus_afterpay/gateway.rb
@@ -30,7 +30,7 @@ module SolidusAfterpay
         )
         result = response.body
       end
-
+      
       ActiveMerchant::Billing::Response.new(true, 'Transaction approved', result, authorization: result[:id])
     rescue ::Afterpay::BaseError => e
       message = e.message
@@ -39,6 +39,7 @@ module SolidusAfterpay
         message = I18n.t('solidus_afterpay.payment_declined')
         error_code = 'payment_declined'
       end
+      ::Afterpay::API::Payment::Reversal.call(token: result[:token])
       ActiveMerchant::Billing::Response.new(false, message, {}, error_code: error_code)
     end
 
@@ -58,6 +59,7 @@ module SolidusAfterpay
 
       ActiveMerchant::Billing::Response.new(true, 'Transaction captured', result, authorization: result.id)
     rescue ::Afterpay::BaseError => e
+      ::Afterpay::API::Payment::Reversal.call(token: response.body[:token])
       ActiveMerchant::Billing::Response.new(false, e.message, {}, error_code: e.error_code)
     end
 

--- a/solidus_afterpay.gemspec
+++ b/solidus_afterpay.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'afterpay', '~> 0.2.0'
+  spec.add_dependency 'afterpay', '~> 0.3.0'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
When the payment gets accepted by `Afterpay` and the store
is getting an error on the capture(auto-capture) or authorize(deferred)
this would undo the payment on Afterpay.