### PR TITLE
Fix express checkout button bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ If you want to override this logic, adding/removing attributes, you can provide 
 ### Express checkout from the cart
 
 An Afterpay button can also be included on the cart view to enable express checkouts:
-> Products should always be an array! Even for a single item.
 
 ```ruby
-<%= render "solidus_afterpay/afterpay_checkout_button", products: [<product>] %>
+<%= render "solidus_afterpay/afterpay_checkout_button" %>
 ```
 
 ### Afterpay Messaging

--- a/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
+++ b/app/views/solidus_afterpay/_afterpay_checkout_button.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'solidus_afterpay/afterpay_javascript', locals: { payment_method: payment_method } if Rails.env != "test" %>
 
-<% if payment_method.present? && products.none? { |product| ::SolidusAfterpay::PaymentMethod.active.first.excluded_product?(product) }  %>
+<% if payment_method.present? && payment_method.available_for_order?(@order)  %>
   <button type="button" id="afterpay-button" data-afterpay-entry-point="cart" data-order-number="<%= @order.number %>" data-payment-method-id="<%= payment_method.id %>">
     <%= I18n.t('solidus_afterpay.express_checkout.button') %>
   </button>

--- a/spec/views/solidus_afterpay/express_checkout_button_spec.rb
+++ b/spec/views/solidus_afterpay/express_checkout_button_spec.rb
@@ -1,35 +1,30 @@
 require "spec_helper"
 
 RSpec.describe "rendering afterpay express checkout button", type: :view do
-  let(:product) { create(:base_product) }
-  let(:second_product) { create(:base_product) }
-  let(:excluded_product) { create(:base_product) }
+  subject(:rendered) { render "solidus_afterpay/afterpay_checkout_button", payment_method: payment_method }
+
   let(:payment_method) { SolidusAfterpay::PaymentMethod.active.first }
-  let(:amount) { product.price }
-  let(:product_array) { [product] }
+  let(:order) { create(:order) }
 
   before do
-    create(:afterpay_payment_method, preferred_excluded_products: excluded_product.id.to_s)
-    assign(:order, create(:order))
-    render "solidus_afterpay/afterpay_checkout_button", products: product_array
+    create(:afterpay_payment_method)
+    assign(:order, order)
   end
 
-  context "when rendering afterpay express checkout button for a single product" do
+  context "when order is available for order" do
+    before do
+      allow(payment_method).to receive(:available_for_order?).with(order).and_return(true)
+    end
+
     it 'displays the afterpay express checkout button' do
       expect(rendered).to match("Checkout with Afterpay")
     end
   end
 
-  context "when rendering afterpay express checkout button for multiple products" do
-    let(:product_array) { [product, second_product] }
-
-    it 'displays the afterpay express checkout button' do
-      expect(rendered).to match("Checkout with Afterpay")
+  context "when order is not available for order" do
+    before do
+      allow(payment_method).to receive(:available_for_order?).with(order).and_return(false)
     end
-  end
-
-  context "when rendering afterpay express checkout button with an excluded product" do
-    let(:product_array) { [product, second_product, excluded_product] }
 
     it 'does not display the afterpay express checkout button' do
       expect(rendered).not_to match("Checkout with Afterpay")


### PR DESCRIPTION
When the amount was out of range of the `Afterpay` maximum
or minimum allowance, the button was still showing, this was
because we only checked if the item was excluded or not.

By using the `#available_for_order?` method from the payment_method
we can check for every clause.

I removed the products array from the documentation about the express checkout button as this is no longer needed.