### PR TITLE
Bump required_ruby_version up to ruby 3.x

### DIFF
--- a/solidus_afterpay.gemspec
+++ b/solidus_afterpay.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_afterpay'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_afterpay/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5', '< 4')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Ruby 2.x support will end in 1 week so the gem needs to start supporting ruby 3.x as well.