### PR TITLE
Bump required ruby version and align controller behaviour

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,12 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Enabled: false
+
+Rspec/RemoveConst:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
@@ -14,13 +14,16 @@ gem 'rails', '>0.a'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-case ENV['DB']
+# The inclusion of this gem has been removed from the dev support gem in recent versions.
+gem 'solidus_frontend'
+
+case ENV.fetch('DB', nil)
 when 'mysql'
   gem 'mysql2'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # Solidus Afterpay
 
 <!-- Explain what your extension does. -->
+> [!IMPORTANT] 
+> This gem still depends on the legacy [solidus_frontend](https://github.com/solidusio/solidus_frontend) gem being available in the Solidus application.
 
 ## Installation
 
@@ -43,6 +45,7 @@ Spree::Config.configure do |config|
     'afterpay_credentials', {
       merchant_id: ENV['AFTERPAY_MERCHANT_ID'],
       secret_key: ENV['AFTERPAY_SECRET_KEY'],
+      test_mode: ENV.fetch('AFTERPAY_ENVIRONMENT', '') != 'production'
     }
   )
 end

--- a/app/controllers/solidus_afterpay/callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/callbacks_controller.rb
@@ -41,7 +41,11 @@ module SolidusAfterpay
     end
 
     def payment_method
-      @payment_method ||= SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
+      @payment_method ||= if params[:payment_method_id]
+                            SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
+                          else
+                            SolidusAfterpay::PaymentMethod.active.first
+                          end
     end
 
     def afterpay_order_token

--- a/app/controllers/solidus_afterpay/express_callbacks_controller.rb
+++ b/app/controllers/solidus_afterpay/express_callbacks_controller.rb
@@ -55,7 +55,11 @@ module SolidusAfterpay
     end
 
     def payment_method
-      @payment_method ||= SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
+      @payment_method ||= if params[:payment_method_id]
+                            SolidusAfterpay::PaymentMethod.active.find(params[:payment_method_id])
+                          else
+                            SolidusAfterpay::PaymentMethod.active.first
+                          end
     end
   end
 end

--- a/app/models/solidus_afterpay/order_component_builder.rb
+++ b/app/models/solidus_afterpay/order_component_builder.rb
@@ -114,7 +114,7 @@ module SolidusAfterpay
 
     def estimated_shipment_date(line_item)
       @estimated_shipment_date ||=
-        (estimated_shipment_date_variant(line_item) || estimated_shipment_date_product(line_item))
+        estimated_shipment_date_variant(line_item) || estimated_shipment_date_product(line_item)
     end
 
     def pre_order?(line_item)

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,7 +22,7 @@ if [ ! -z $SOLIDUS_BRANCH ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
-  BRANCH="master"
+  BRANCH="main"
 fi
 
 extension_name="solidus_afterpay"

--- a/lib/solidus_afterpay/configuration.rb
+++ b/lib/solidus_afterpay/configuration.rb
@@ -41,7 +41,14 @@ module SolidusAfterpay
       SolidusAfterpay::BaseController
     end
 
-    delegate :shipping_rate_builder_service_class, to: :configuration
-    delegate :update_order_attributes_service_class, to: :configuration
+    # rubocop:disable Rails/Delegate
+    def shipping_rate_builder_service_class
+      configuration.shipping_rate_builder_service_class
+    end
+
+    def update_order_attributes_service_class
+      configuration.update_order_attributes_service_class
+    end
+    # rubocop:enable Rails/Delegate
   end
 end

--- a/lib/solidus_afterpay/engine.rb
+++ b/lib/solidus_afterpay/engine.rb
@@ -19,7 +19,7 @@ module SolidusAfterpay
     initializer "spree.payment_methods.register_afterpay_payment_method",
       after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << "SolidusAfterpay::PaymentMethod"
-      Spree::PermittedAttributes.source_attributes.concat [:token]
+      Spree::PermittedAttributes.source_attributes.push :token
     end
   end
 end

--- a/lib/solidus_afterpay/testing_support/factories.rb
+++ b/lib/solidus_afterpay/testing_support/factories.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
   factory :order_with_variant_property, class: "Spree::Order", parent: :order_with_line_items do
     after(:build) do |order|
       variant_property_rule_value = create(:variant_property_rule_value, value: "2021-09-19",
-property: create(:property, name: "estimatedShipmentDate"))
+        property: create(:property, name: "estimatedShipmentDate"))
       order.line_items.first.variant.product.variant_property_rules << variant_property_rule_value.variant_property_rule
       order.line_items.first.variant.option_values << variant_property_rule_value.variant_property_rule
                                                                                  .option_values.first

--- a/lib/solidus_afterpay/version.rb
+++ b/lib/solidus_afterpay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusAfterpay
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/solidus_afterpay.gemspec
+++ b/solidus_afterpay.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_afterpay'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_afterpay/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5', '< 4')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/solidus_afterpay.gemspec
+++ b/solidus_afterpay.gemspec
@@ -23,16 +23,16 @@ Gem::Specification.new do |spec|
   files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }
 
   spec.files = files.grep_v(%r{^(test|spec|features)/})
-  spec.test_files = files.grep(%r{^(test|spec|features)/})
   spec.bindir = "exe"
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'afterpay', '~> 0.5.0'
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'afterpay', '~> 0.6.0'
+  spec.add_dependency 'solidus_core', ['>= 2.0.0']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.14'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/helpers/solidus_afterpay/afterpay_helper_spec.rb
+++ b/spec/helpers/solidus_afterpay/afterpay_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SolidusAfterpay::AfterpayHelper, type: :helper do
+RSpec.describe SolidusAfterpay::AfterpayHelper do
   describe '#include_afterpay_js' do
     subject { helper.include_afterpay_js(test_mode: test_mode) }
 

--- a/spec/models/solidus_afterpay/gateway_spec.rb
+++ b/spec/models/solidus_afterpay/gateway_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe SolidusAfterpay::Gateway do
 
       context 'with a timeout error' do
         before do
-          allow(::Afterpay::API::Payment::Auth).to receive(:call).and_raise(
-            ::Afterpay::RequestTimeoutError.new('request_timeout'), 'Request Timeout'
+          allow(Afterpay::API::Payment::Auth).to receive(:call).and_raise(
+            Afterpay::RequestTimeoutError.new('request_timeout'), 'Request Timeout'
           )
-          allow(::Afterpay::API::Payment::Reversal).to receive(:call)
+          allow(Afterpay::API::Payment::Reversal).to receive(:call)
         end
 
         it 'returns an unsuccesfull response' do
@@ -94,7 +94,7 @@ RSpec.describe SolidusAfterpay::Gateway do
 
         it 'calls the ::Afterpay::API::Payment::Reversal with order token' do
           response
-          expect(::Afterpay::API::Payment::Reversal).to have_received(:call).with(token: order_token)
+          expect(Afterpay::API::Payment::Reversal).to have_received(:call).with(token: order_token)
         end
       end
     end
@@ -182,10 +182,10 @@ RSpec.describe SolidusAfterpay::Gateway do
 
       context 'with a timeout error' do
         before do
-          allow(::Afterpay::API::Payment::DeferredCapture).to receive(:call).and_raise(
-            ::Afterpay::RequestTimeoutError.new('request_timeout'), 'Request Timeout'
+          allow(Afterpay::API::Payment::DeferredCapture).to receive(:call).and_raise(
+            Afterpay::RequestTimeoutError.new('request_timeout'), 'Request Timeout'
           )
-          allow(::Afterpay::API::Payment::Reversal).to receive(:call)
+          allow(Afterpay::API::Payment::Reversal).to receive(:call)
         end
 
         it 'returns an unsuccesfull response' do
@@ -202,7 +202,7 @@ RSpec.describe SolidusAfterpay::Gateway do
 
         it 'calls the ::Afterpay::API::Payment::Reversal with order token' do
           response
-          expect(::Afterpay::API::Payment::Reversal).to have_received(:call).with(token: order_token)
+          expect(Afterpay::API::Payment::Reversal).to have_received(:call).with(token: order_token)
         end
       end
     end
@@ -481,7 +481,7 @@ RSpec.describe SolidusAfterpay::Gateway do
 
     context 'with invalid response' do
       before do
-        allow(::Afterpay::API::Configuration::Retrieve).to receive(:call).and_raise(::Afterpay::BaseError.new(nil))
+        allow(Afterpay::API::Configuration::Retrieve).to receive(:call).and_raise(Afterpay::BaseError.new(nil))
       end
 
       it 'retrieves the afterpay configuration' do

--- a/spec/models/solidus_afterpay/payment_method_spec.rb
+++ b/spec/models/solidus_afterpay/payment_method_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SolidusAfterpay::PaymentMethod, type: :model do
+RSpec.describe SolidusAfterpay::PaymentMethod do
   let(:payment_method) { described_class.new }
 
   describe "#gateway_class" do
@@ -84,7 +84,7 @@ RSpec.describe SolidusAfterpay::PaymentMethod, type: :model do
     let(:payment_method) { create(:afterpay_payment_method, preferred_excluded_products: excluded_product_ids) }
     let(:order) {
       build(:order_with_line_items, currency: order_currency,
-     line_items_attributes: line_items_attributes)
+        line_items_attributes: line_items_attributes)
     }
     let(:line_items_attributes) do
       [{ product: product }]

--- a/spec/models/solidus_afterpay/payment_source_spec.rb
+++ b/spec/models/solidus_afterpay/payment_source_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SolidusAfterpay::PaymentSource, type: :model do
+RSpec.describe SolidusAfterpay::PaymentSource do
   let(:payment_source) { described_class.new }
 
   describe '#actions' do

--- a/spec/models/solidus_afterpay/user_agent_generator_spec.rb
+++ b/spec/models/solidus_afterpay/user_agent_generator_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe SolidusAfterpay::UserAgentGenerator do
 
     before do
       stub_const('SolidusAfterpay::VERSION', '0.1.0')
-      allow(::Spree).to receive(:solidus_gem_version).and_return('3.0.1')
+      allow(Spree).to receive(:solidus_gem_version).and_return('3.0.1')
       stub_const('RUBY_VERSION', '2.6.6')
-      allow(::Spree::Store).to receive(:default).and_return(default_store)
+      allow(Spree::Store).to receive(:default).and_return(default_store)
     end
 
     it 'includes the production javascript' do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Order, type: :model do
+RSpec.describe Spree::Order do
   let(:store) { create(:store) }
   let(:user) { create(:user, email: "solidus@example.com") }
   let(:order) { create(:order, user: user, store: store) }
@@ -55,12 +55,12 @@ RSpec.describe Spree::Order, type: :model do
       subject { order.available_payment_methods }
 
       let!(:first_method) {
-        FactoryBot.create(:payment_method, available_to_users: true,
-                                               available_to_admin: true)
+        create(:payment_method, available_to_users: true,
+          available_to_admin: true)
       }
       let!(:second_method) {
-        FactoryBot.create(:payment_method, available_to_users: true,
-                                               available_to_admin: true)
+        create(:payment_method, available_to_users: true,
+          available_to_admin: true)
       }
 
       before do
@@ -120,9 +120,7 @@ RSpec.describe Spree::Order, type: :model do
         before { order.update!(store: store_with_payment_methods) }
 
         it 'returns only the matching payment methods for that store' do
-          expect(order.available_payment_methods).to match_array(
-            [payment_method_with_store]
-          )
+          expect(order.available_payment_methods).to contain_exactly(payment_method_with_store)
         end
 
         context 'when the store has an extra payment method unavailable to users' do
@@ -137,9 +135,7 @@ RSpec.describe Spree::Order, type: :model do
           end
 
           it 'returns only the payment methods available to users for that store' do
-            expect(order.available_payment_methods).to match_array(
-              [payment_method_with_store]
-            )
+            expect(order.available_payment_methods).to contain_exactly(payment_method_with_store)
           end
         end
       end
@@ -148,9 +144,8 @@ RSpec.describe Spree::Order, type: :model do
         before { order.update!(store: store_without_payment_methods) }
 
         it 'returns all matching payment methods regardless of store' do
-          expect(order.available_payment_methods).to match_array(
-            [payment_method_with_store, payment_method_without_store]
-          )
+          expect(order.available_payment_methods).to contain_exactly(payment_method_with_store,
+            payment_method_without_store)
         end
       end
     end

--- a/spec/presenters/solidus_afterpay/shipping_rate_presenter_spec.rb
+++ b/spec/presenters/solidus_afterpay/shipping_rate_presenter_spec.rb
@@ -6,7 +6,7 @@ describe SolidusAfterpay::ShippingRatePresenter do
   let(:order) { create(:order_with_line_items ) }
   let(:shipment) { create(:shipment, order: order) }
   let(:shipping_rate) { create(:shipping_rate, cost: 5, shipment: shipment) }
-  let(:shipping_rate_tax) { ::Spree::ShippingRateTax.create(amount: 0.75, shipping_rate: shipping_rate) }
+  let(:shipping_rate_tax) { Spree::ShippingRateTax.create(amount: 0.75, shipping_rate: shipping_rate) }
 
   before { shipping_rate.taxes << shipping_rate_tax }
 

--- a/spec/requests/solidus_afterpay/callbacks_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/callbacks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe SolidusAfterpay::CallbacksController, type: :request do
+describe SolidusAfterpay::CallbacksController do
   describe 'GET cancel' do
     subject(:request) { get '/solidus_afterpay/callbacks/cancel', params: params }
 
@@ -29,7 +29,7 @@ describe SolidusAfterpay::CallbacksController, type: :request do
 
     let(:params) { { orderToken: order_token, order_number: order_number, payment_method_id: payment_method_id } }
 
-    context 'when the user is logged in', with_signed_in_user: true do
+    context 'when the user is logged in', :with_signed_in_user do
       context 'with valid data' do
         it 'redirects to the order next checkout state page' do
           request
@@ -110,7 +110,7 @@ describe SolidusAfterpay::CallbacksController, type: :request do
       end
     end
 
-    context 'when the user is a guest user', with_guest_session: true do
+    context 'when the user is a guest user', :with_guest_session do
       it 'redirects to the order next checkout state page' do
         request
         expect(response).to redirect_to('/checkout/confirm')

--- a/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/checkouts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe SolidusAfterpay::CheckoutsController, type: :request do
+describe SolidusAfterpay::CheckoutsController do
   describe 'POST create' do
     subject(:request) { post '/solidus_afterpay/checkouts.json', params: params, headers: headers }
 
@@ -38,7 +38,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
     end
 
     context 'when the use solidus api config is set to false' do
-      context 'when the user is logged in', with_signed_in_user: true do
+      context 'when the user is logged in', :with_signed_in_user do
         context 'with valid data' do
           before do
             allow(Spree::Order).to receive(:find_by!).with(number: order.number).and_return(order)
@@ -50,11 +50,11 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
           end
 
           it 'returns the order_token' do
-            expect(JSON.parse(response.body)['token']).to eq(order_token)
+            expect(response.parsed_body['token']).to eq(order_token)
           end
 
           it 'returns the correct params' do
-            expect(JSON.parse(response.body)).to include('token', 'expires', 'redirectCheckoutUrl')
+            expect(response.parsed_body).to include('token', 'expires', 'redirectCheckoutUrl')
           end
 
           context 'when no redirect URLs are passed as params' do
@@ -140,7 +140,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
           end
 
           it 'returns a resource not found error message' do
-            expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+            expect(response.parsed_body['error']).to eq('The resource you were looking for could not be found.')
           end
         end
 
@@ -154,7 +154,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
           end
 
           it 'returns a resource not found error message' do
-            expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+            expect(response.parsed_body['error']).to eq('The resource you were looking for could not be found.')
           end
         end
 
@@ -202,16 +202,16 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
           end
 
           it 'returns a resource not found error message' do
-            expect(JSON.parse(response.body)['error']).to eq(gateway_response_message)
+            expect(response.parsed_body['error']).to eq(gateway_response_message)
           end
 
           it 'returns the error_code' do
-            expect(JSON.parse(response.body)['errorCode']).to eq(gateway_response_error_code)
+            expect(response.parsed_body['errorCode']).to eq(gateway_response_error_code)
           end
         end
       end
 
-      context 'when the user is a guest user', with_guest_session: true do
+      context 'when the user is a guest user', :with_guest_session do
         it 'returns a 201 status code' do
           request
           expect(response).to have_http_status(:created)
@@ -226,7 +226,7 @@ describe SolidusAfterpay::CheckoutsController, type: :request do
       end
     end
 
-    context 'when the use solidus api config is set to true', use_solidus_api: true do
+    context 'when the use solidus api config is set to true', :use_solidus_api do
       context 'when the user is logged in' do
         let(:headers) { { Authorization: "Bearer #{user.spree_api_key}" } }
 

--- a/spec/requests/solidus_afterpay/express_callbacks_controller_spec.rb
+++ b/spec/requests/solidus_afterpay/express_callbacks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe SolidusAfterpay::ExpressCallbacksController, type: :request do
+describe SolidusAfterpay::ExpressCallbacksController do
   describe 'PATCH update' do
     subject(:request) { patch "/solidus_afterpay/express_callbacks/#{order.number}.json", params: params }
 
@@ -31,14 +31,14 @@ describe SolidusAfterpay::ExpressCallbacksController, type: :request do
       end
     end
 
-    context 'when the user is a guest user', with_guest_session: true do
+    context 'when the user is a guest user', :with_guest_session do
       it 'returns 200 status code' do
         request
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when the user is logged in', with_signed_in_user: true do
+    context 'when the user is logged in', :with_signed_in_user do
       let(:update_order_address_service_result) { true }
 
       before do
@@ -120,14 +120,14 @@ describe SolidusAfterpay::ExpressCallbacksController, type: :request do
       end
     end
 
-    context 'when the user is a guest user', with_guest_session: true do
+    context 'when the user is a guest user', :with_guest_session do
       it 'returns 200 status code' do
         request
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when the user is logged in', with_signed_in_user: true do
+    context 'when the user is logged in', :with_signed_in_user do
       it 'returns 200 status code' do
         request
         expect(response).to have_http_status(:ok)
@@ -151,7 +151,7 @@ describe SolidusAfterpay::ExpressCallbacksController, type: :request do
 
       it 'redirects the user to the checkout confirm step' do
         request
-        expect(JSON.parse(response.body)['redirect_url']).to eq('http://www.example.com/checkout/confirm')
+        expect(response.parsed_body['redirect_url']).to eq('http://www.example.com/checkout/confirm')
       end
 
       context 'when the update order attributes service fails' do

--- a/spec/services/solidus_afterpay/base_service_spec.rb
+++ b/spec/services/solidus_afterpay/base_service_spec.rb
@@ -7,7 +7,7 @@ describe SolidusAfterpay::BaseService do
     subject(:service) { described_class.new.call }
 
     it 'raises a not implemented error' do
-      expect { service }.to raise_error(::NotImplementedError)
+      expect { service }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/services/solidus_afterpay/shipping_rate_builder_service_spec.rb
+++ b/spec/services/solidus_afterpay/shipping_rate_builder_service_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe SolidusAfterpay::ShippingRateBuilderService do
   subject(:service) { described_class.call(order: order) }
 
-  let(:order) { ::Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
 
   context 'when the order is in a valid state' do
     it 'returns the afterpay compliant shipping rate object' do

--- a/spec/support/auth.rb
+++ b/spec/support/auth.rb
@@ -3,9 +3,9 @@
 RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
 
-  config.before(:each, with_signed_in_user: true) { login_as user }
+  config.before(:each, :with_signed_in_user) { login_as user }
 
-  config.before(:each, with_guest_session: true) do
+  config.before(:each, :with_guest_session) do
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(ActionDispatch::Cookies::CookieJar).to(
       receive(:signed).and_return({ guest_token: order.guest_token })

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     end.uniq.first
   end
 
-  config.before(:each, use_solidus_api: true) do
+  config.before(:each, :use_solidus_api) do
     SolidusAfterpay.configure do |c|
       c.use_solidus_api = true
     end
@@ -19,7 +19,7 @@ RSpec.configure do |config|
     load source_location
   end
 
-  config.after(:each, use_solidus_api: true) do
+  config.after(:each, :use_solidus_api) do
     SolidusAfterpay.configure do |c|
       c.use_solidus_api = false
     end

--- a/spec/views/solidus_afterpay/express_checkout_button_spec.rb
+++ b/spec/views/solidus_afterpay/express_checkout_button_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "rendering afterpay express checkout button", type: :view do
+RSpec.describe "rendering afterpay express checkout button" do
   subject(:rendered) { render "solidus_afterpay/afterpay_checkout_button", payment_method: payment_method }
 
   let(:payment_method) { SolidusAfterpay::PaymentMethod.active.first }

--- a/spec/views/spree/shared/afterpay_messaging_spec.rb
+++ b/spec/views/spree/shared/afterpay_messaging_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
-
-RSpec.describe "rendering afterpay messaging", type: :view do
+RSpec.describe "rendering afterpay messaging" do
   let(:product) { create(:base_product) }
   let(:second_product) { create(:base_product) }
   let(:excluded_product) { create(:base_product) }


### PR DESCRIPTION
Specs pass locally on ruby 3.3 and these changes are running in a ruby 3.1 client application.

- Allows ruby 3.X
- Aligns controller behaviour when the payment method is not passed into the params
- Lints with rubocop 
- Fixes CI